### PR TITLE
comrade matrices close #23

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpecialPolynomials"
 uuid = "a25cea48-d430-424a-8ee7-0d3ad3742e9e"
 authors = ["jverzani <jverzani@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 HypergeometricFunctions = "34004b35-14d8-5ef3-9330-4cdb6864b03a"

--- a/build/Bernstein.jl
+++ b/build/Bernstein.jl
@@ -1,0 +1,461 @@
+abstract type AbstractBernstein{T,X} <: AbstractSpecialPolynomial{T,X} end
+
+"""
+
+    Bernstein{N, T, X}
+
+A [Bernstein  polynomial](https://en.wikipedia.org/wiki/Bernstein_polynomial) is a polynomial expressed in terms of
+Bernstein basic polynomials. For each degree, `𝐍`, this is a set of `𝐍+1` degree `𝐍` polynomials of the form:
+`β_{𝐍,ν} =  (ν choose 𝐍) x^ν  (1-x)^{𝐍-ν}`, `0 ≤ x ≤ 1.`
+
+The `Bernstein{𝐍,T}` type represents a polynomial of degree `𝐍` or
+less with a linear combination of the basis vectors using coefficients
+of type `T`.
+
+```jldoctest Bernstein
+julia> using Polynomials, SpecialPolynomials
+
+julia> p = basis(Bernstein{3},  2)
+Bernstein(1⋅β₂,₂(x))
+
+julia> convert(Polynomial, p)
+Polynomials.Polynomial(1.0*x^2)
+```
+
+!!! note
+    [StaticUnivariatePolynomials](https://github.com/tkoolen/StaticUnivariatePolynomials.jl) Offers a  more  performant version.
+
+"""
+struct Bernstein{𝐍, T, X} <: AbstractBernstein{T, X}
+    coeffs::Vector{T}
+    function Bernstein{𝐍, T, X}(coeffs::AbstractVector{T})  where {𝐍, T, X}
+        N = findlast(!iszero, coeffs)
+        N == nothing && return new{𝐍,T,X}(zeros(T,0))
+        (N > 𝐍 + 1) && throw(ArgumentError("Wrong length for coefficents"))
+        return new{𝐍, T, X}(coeffs[1:N])
+    end
+end
+
+export Bernstein
+Polynomials.@registerN Bernstein 𝐍
+Polynomials.:⟒(::Type{<:Bernstein{𝐍}}) where  {𝐍} = Bernstein{𝐍}
+
+function Polynomials.showterm(io::IO, ::Type{Bernstein{N,T,X}}, pj::T, var, j, first::Bool, mimetype) where {N, T, X}
+    iszero(pj) && return false
+    !first &&  print(io, " ")
+    print(io, Polynomials.hasneg(T) && Polynomials.isneg(pj) ? "- " :  (!first ? "+ " : ""))
+    print(io, "$(abs.(pj))⋅β")
+    Polynomials.unicode_subscript(io, N)
+    print(io, ",")
+    Polynomials.unicode_subscript(io, j)
+    print(io, "($var)")
+    return true
+end
+
+# add default case with no N specified
+function Bernstein(coeffs::AbstractVector{T}, var::Symbol=:x)  where {T}
+    l = findlast(!iszero,  coeffs)
+    𝐍 = l == nothing ?  -1 :  l - 1
+    Bernstein{𝐍, T, Symbol(var)}(coeffs[1:𝐍+1])
+end
+
+# promotion between family
+function Base.promote(p::P, q::Q) where {𝐍,T,X,P<:Bernstein{𝐍,T,X}, 𝐌,S,Y,Q<:Bernstein{𝐌,S,Y}}
+    X == Y || throw(ArgumentError("different indeterminates"))
+    MN = max(𝐌,𝐍)
+    R = promote_type(T,S)
+    PQ = Bernstein{MN,R}
+    convert(PQ,p), convert(PQ,q)
+end
+
+# promote up
+function Base.convert(P::Type{<:Bernstein{𝐍}}, p::Bernstein{𝐌, S}) where {𝐍, 𝐌, S}
+    @assert  𝐍 >=  𝐌
+    𝐑 = 𝐍 -  𝐌
+    R = eltype(one(promote_type(eltype(P),S))/1)
+    cs = zeros(R, 𝐍 +  1)
+    for  j  in 0:𝐌
+        pⱼ = p[j]
+        iszero(pⱼ) &&  continue
+        for  i  in j:j+𝐑
+            cs[1+i] +=  pⱼ * binomial(𝐌,j) * binomial(𝐑, i-j) /  binomial(𝐍, i)
+        end
+    end
+    X = Polynomials.indeterminate(P, p)
+    Bernstein{𝐍, R, X}(cs)
+
+end
+
+
+function Base.convert(P::Type{<:Polynomials.StandardBasisPolynomial}, p::Bernstein{N,T}) where {N, T}
+    x = variable(P)
+    p(x)
+end
+
+function Base.convert(C::Type{<:Bernstein{𝐍, T}}, p::Polynomial) where {𝐍, T}
+
+    @assert degree(p) <= 𝐍
+
+    R = eltype(one(T)/one(Int))
+    cs = zeros(R, 𝐍+1)
+
+    for (i, a_nu) in enumerate(coeffs(p))
+        k = i - 1
+        nk = binomial(𝐍,k)
+        for j in k:𝐍
+            cs[j+1] += a_nu/nk*binomial(j,k)
+        end
+    end
+
+    X = Polynomials.indeterminate(C,p)
+    Bernstein{𝐍, R, X}(cs)
+end
+
+function Base.convert(P::Type{<:AbstractBernstein}, p::Polynomial{T}) where {T}
+    𝐍 = degree(p)
+    X = Polynomials.indeterminate(P,p)
+    convert(Bernstein{𝐍, T, X}, p)
+end
+
+
+
+Polynomials.domain(::Type{<:AbstractBernstein}) = Polynomials.Interval(0, 1)
+Polynomials.degree(p::Bernstein{N,T, X}) where {N, T, X} = degree(convert(Polynomial{T, X}, p))
+
+Polynomials.constantterm(p::Bernstein) = p[0] # β.,ᵢ = 0 + ... when i > 0
+
+## need to do one  and variable differently,as coefficients have length N+1
+Base.one(P::Type{Bernstein{N,T,X}}) where {N,T,X} = Bernstein{N,T,X}(ones(T, N+1))
+Base.one(P::Type{Bernstein{N,T}}, var::Polynomials.SymbolLike) where {N,T} = Bernstein{N,T, Symbol(var)}(ones(T, N+1))
+function Base.one(P::Type{<:Bernstein{N}}, var::Polynomials.SymbolLike=:x) where {N}
+    N′ = max(N,0)
+    one(Bernstein{N′,eltype(P),Symbol(var)})
+end
+
+function Polynomials.variable(P::Type{Bernstein{𝐍,T,X}}) where {𝐍,T,X}
+    𝐍 <= 0 && throw(ArgumentError("Need  𝐍 ≥ 1"))
+    R = typeof(one(T)/1)
+    Bernstein{𝐍,R,X}([1 - (i*one(T))/𝐍 for i in 𝐍:-1:0])
+end
+
+function Polynomials.variable(P::Type{<:Bernstein{𝐍}}, var::Polynomials.SymbolLike=:x) where {𝐍}
+    S = eltype(P)
+    variable(Bernstein{𝐍,S,Symbol(var)})
+end
+Polynomials.variable(P::Type{Bernstein},  var::Polynomials.SymbolLike=:x) = variable(Bernstein{1, eltype(P),Symbol(var)})
+
+function basis(::Type{P}, k::Int) where {𝐍,T,X,P<:Bernstein{𝐍,T,X}}
+    zs = zeros(Int, k+1)
+    zs[end] = 1
+    P(zs)
+end
+
+function basis(P::Type{<:Bernstein}, k::Int, _var::Polynomials.SymbolLike=:x; var=_var)
+    zs = zeros(Int, k+1)
+    zs[end] = 1
+    Bernstein(zs, var)
+end
+
+
+
+# poly evaluation
+Polynomials.evalpoly(x, p::Bernstein) = simple_deCasteljau_polyval(p, x)
+
+# we could  use the compensated one
+# from https://doi.org/10.1016/j.camwa.2010.05.021
+# Accurate evaluation of a polynomial and its derivative in Bernstein form
+# Hao Jiang, Shengguo Li, Lizhi Cheng, and Fang Su
+#
+# for increased accuracy, but is it really necessary here?
+function simple_deCasteljau_polyval(p::Bernstein{𝐍,T,X}, t::S) where {𝐍,T, X, S}
+
+    p₀ = p[0]
+    R = eltype(p₀*t)
+    zR = p₀ * zero(t)
+
+    R = promote_type(T, S)
+    𝐍 == -1 && return zR
+    𝐍 == 0  && return p[0] * one(t)
+    n = length(coeffs(p))
+    iszero(n) && return zR
+
+    bs = [zR for _ ∈ 1:𝐍+1]
+    for i in eachindex(coeffs(p))
+        bs[i] = p[i-1]
+    end
+
+    r = 1-t
+    for j in 1:𝐍
+        for i = 0:𝐍-j
+            ii = i + 1
+            bs[ii] = bs[ii]*r + bs[ii+1]*t
+        end
+    end
+    bs[1]
+end
+
+# function deCasteljau_polyval(p::Bernstein{N,T}, t) where {N, T}
+#     b̂ = coeffs(p) .* one(t)
+#     errb̂ = 0 .* b̂ #zeros(eltype(b̂), N+1)
+#     r̂,ρ = twoSum(1, -t)
+#     for j in 1:N
+#         for ii in 0:(N-j)
+#             i = ii+1
+#             s, π̂ = twoProd(b̂[i], r̂)
+#             v, σ̂ = twoProd(b̂[i+1], t)
+#             b̂[i],β̂ = twoSum(s, v)
+#             ŵ = π̂ .+ σ̂ .+ β̂ .+ (b̂[i] .* ρ)
+#             errb̂[i] = errb̂[i] * r̂ + (errb̂[i+1] * t + ŵ)
+#         end
+#     end
+#     b̂[1]+ errb̂[1]
+
+# end
+
+
+
+# # compensated form to  find p'(t)
+# function deCasteljau_derivative_val(p::Bernstein{N,T}, t) where {N,T}
+#     R = eltype(one(T)*one(eltype(t)))
+#     r̂,ρ  = twoSum(one(R), -t)
+#     Δb = zeros(R, N).*one(t)
+#     errΔb = similar(Δb) #zeros(R, N).*one(t)
+#     for ii=0:N-1
+#         i = ii+1
+#         Δb[i], errΔb[i] = twoSum(p[ii+1], -p[ii])
+#     end
+#     for j in 1:N-1
+#         for ii in 0:N-1-j
+#             i = ii+1
+#             s, π̂ = twoProd(Δb[i], r̂)
+#             v, σ̂ = twoProd(Δb[i+1], t)
+#             Δb[i], β̂ = twoSum(s, v)
+#             ŵ = π̂ + σ̂ + β̂ + (Δb[i] * ρ)
+#             errΔb[i] = errΔb[i] * r̂ + (errΔb[i+1] * t + ŵ)
+#         end
+#     end
+#     (Δb[1] + errΔb[1]) * N
+# end
+
+# # Moller-Knuth from Exact computations with approximate arithmetic
+# # http://perso.ens-lyon.fr/jean-michel.muller/
+# function twoSum(a::Number, b::Number)
+#     s = a + b
+#     â = s - b
+#     b̂ = s - â
+#     δ_a = a - â
+#     δ_b = b - b̂
+#     s, δ_a + δ_b
+# end
+# twoSum(x, y) = (x + y, zero(x)+zero(y))
+
+# function twoProd(a::Number, b::Number)
+#     ab = a * b
+#     ab, fma(a,b,-ab)
+# end
+# twoProd(x, y)  = x*y, 0
+
+
+# not needed, but speeds things along
+function Base.:+(p1::P, p2::Q) where {𝐍,T,X,P<:Bernstein{𝐍,T,X},
+                                      𝐌,S,  Q<:Bernstein{𝐌,S,X}}
+    p,q = promote(p1, p2)
+    𝐎,R = length(p.coeffs), eltype(p)
+    P′ = Bernstein{𝐎,R,X}
+    return Bernstein([p[i] + q[i] for i in 0:𝐎], X)
+end
+
+# no promote(p1,p2)  called here
+function Base.:*(p::P, q::Q) where {𝐍,T,X, P<:Bernstein{𝐍,T,X},
+                                    𝐌,S,Y, Q<:Bernstein{𝐌,S,Y}}
+    ## use b(n,k) * b(m,j) = choose(n,k)choose(m,j)/choose(n+m,k+j) b(n+m, k+j)
+
+    isconstant(p) && return q * constantterm(p)
+    isconstant(q) && return p * constantterm(q)
+    Polynomials.assert_same_variable(p, q) || throw(ArgumentError("p1 and p2 must have the same symbol"))
+
+
+    R = typeof(one(promote_type(T,S))/1)
+    x = variable(Polynomial{R})
+    return convert(Bernstein, p(x)*q(x))
+
+    ## multiplication  through conversion  is as  efficient
+    # n,  m =  degree(p), degree(q)
+    # 𝐍 = n + m
+    # cs = zeros(R, 𝐍 + 1)
+
+    # for i in 0:𝐍
+    #     for j in max(0,i-m):min(n, i)
+    #         cs[1+i] += p[j] * q[i-j] * (one(R) * binomial(n,j)  *  binomial(m,i-j))
+    #     end
+    #     cs[1+i] /= binomial(m+n, i)
+    # end
+
+    # Bernstein{𝐍,R}(cs, p.var)
+
+end
+
+#  use p'(t) = n ∑ (b_{i+1} - b_i) B_i,n-1
+function Polynomials.derivative(p::Bernstein{𝐍, T, X}, order::Integer = 1) where {𝐍, T, X}
+    cs = coeffs(p)
+    𝐍 < -1 &&  return p
+    iszero(𝐍) && return zero(p)
+    order ==  0 && return p
+
+    cs = zeros(T, 𝐍)
+    dp = Bernstein{𝐍-1, T, X}(𝐍 * diff(coeffs(p)))
+
+    order > 1 ? derivative(dp, order-1) : dp
+end
+
+
+
+# use ∫b_n,nu  = 1/(n+1)  * ∑_{nu+1}^{n+1} b_n+1, j
+function Polynomials.integrate(p::Bernstein{𝐍, T, X}) where {𝐍, T,X}
+    R = eltype(one(T) / 1)
+    𝐍𝐍 = 𝐍 + 1
+
+    cs = zeros(R, 𝐍𝐍+1)
+
+    @inbounds for ν in eachindex(p)
+        for j in (ν+1):𝐍𝐍
+            cs[1 + j] += p[ν] / 𝐍𝐍
+        end
+    end
+
+    ∫p = Bernstein{𝐍𝐍, R,X}(cs)
+    return ∫p
+
+end
+
+#  could do p 33 of http://mae.engr.ucdavis.edu/~farouki/bernstein.pdf
+function Base.divrem(num::Bernstein{𝐍,T}, den::Bernstein{𝐌,S}) where {𝐍, T, 𝐌, S}
+    R = eltype((one(T)+one(S))/1)
+    p1 = convert(Polynomial{R}, num)
+    p2 = convert(Polynomial{R}, den)
+    q,r = divrem(p1, p2)
+    convert.(Bernstein, (q,r))
+end
+
+# Replace me. Doesn't seem necessary and poor stability of conversion.
+# cf https://arxiv.org/pdf/1910.01998.pdf for one possible way, though for approximate GCD
+function Base.gcd(num::Bernstein{𝐍,T}, den::Bernstein{𝐌,S}) where {𝐍, T, 𝐌, S}
+    ps = convert.(Polynomial, (num,den))
+    qs = gcd(ps...)
+    convert.(Bernstein, qs)
+end
+
+
+
+function Polynomials.vander(P::Type{<:AbstractBernstein}, xs::AbstractVector{T}, n::Integer) where {T <: Number}
+    N = length(xs) - 1 # xs = [x0, x1, ...]
+    R = typeof(one(T)/one(T))
+    V = zeros(R, N+1, n+1)
+    for j in 0:n
+        bnj = binomial(n,j)
+        for i in 0:N
+            x = xs[i+1]
+            V[i+1, j+1] = bnj * x^j * (1-x)^(n-j)     #beta(n,j)(xj)
+        end
+    end
+    V
+end
+
+# direct compuation of roots using numerical stable method of y Guðbjörn and Jónsson as
+# noted by Corless, Sevyeri  in §2.1 of
+# https://arxiv.org/pdf/1910.01998.pdf
+function Polynomials.roots(p::Bernstein{𝐍,T}) where {𝐍,T}
+
+    R = eltype(one(T)/1)
+
+    as = zeros(R, 𝐍 + 1)
+    for (i,pᵢ) ∈ pairs(coeffs(p))
+        as[i] = pᵢ
+    end
+
+    Ap = diagm(-1 => ones(R, 𝐍-1))
+    for j in 1:𝐍
+        Ap[1,j] = -as[end-j]
+    end
+
+    Bp = diagm(-1 => ones(R, 𝐍-1))
+    for j in 1:𝐍
+        Bp[1,j] = -as[end-j]
+    end
+
+    for j in 2:𝐍
+        Bp[j,j] = j/(𝐍-j+1)
+    end
+    Bp[1,1] += as[end]/𝐍
+
+    eigvals(Ap,Bp)
+end
+
+
+# http://www.cecm.sfu.ca/personal/pborwein/MITACS/papers/LinMatPol.pdf
+# Sec 4.1
+
+function comrade_matrix(p::P) where {𝐍, T, P <: Bernstein{𝐍, T}}
+    C₀, C₁ = comrade_pencil(p)
+    C₀ * inv(C₁)
+end
+
+
+function comrade_pencil(p::P) where {𝐍, T, P <: Bernstein{𝐍, T}}
+    n = 𝐍
+    a,b = 0, 1
+    C₀ = diagm( 0 => a/(b-a) .* ((n:-1:1) ./ (1:n)) .* ones(T, n),
+               -1 => b/(b-a) .* ones(T, n-1))
+    C₁ = diagm( 0 => 1/(b-a) .* ((n:-1:1) ./ (1:n)) .* ones(T, n),
+                -1 => 1/(b-a) .* ones(T, n-1))
+
+    C₀[end,end] *= p[end]
+    C₁[end,end] *= p[end]
+
+    for i ∈ 0:n-1
+        C₀[1+i, end] -= b/(b-a) * p[i]
+        C₁[1+i, end] -= 1/(b-a) * p[i]
+    end
+#    C₁[1,end] = -(n-1)/(b-a) * p[0]
+
+    C₀, C₁
+
+end
+
+# block version
+function comrade_pencil(p::P) where {𝐍, T, M <: AbstractMatrix{T},
+                                     P <: Bernstein{𝐍,M}}
+
+    m,m′ = size(p[0])
+    @assert m == m′
+
+    Iₘ = I(m)
+    n = 𝐍
+
+    a,b = 0, 1 # could generalize with Bernsteing
+    R = eltype(one(T)/1)
+    C₀ = zeros(R, n*m, n*m)
+    C₁ = zeros(R, n*m, n*m)
+    Δ = 1:m
+
+    for i ∈ 1:n-1
+        C₀[(i-1)*m .+ Δ, (i-1)*m .+ Δ] .= (n+1 - i)/i * a/(b-a) .* Iₘ
+        C₀[i*m .+ Δ,     (i-1)*m .+ Δ] .= b/(b-a) .* Iₘ
+
+        C₁[(i-1)*m .+ Δ, (i-1)*m .+ Δ] .= (n+1 - i)/i * 1/(b-a) .* Iₘ
+        C₁[i*m .+ Δ,     (i-1)*m .+ Δ] .= 1/(b-a) .* Iₘ
+    end
+
+    C₀[(n-1)*m .+ Δ, (n-1)*m .+ Δ] .= 1/n * a/(b-a) .* p[n]
+    C₁[(n-1)*m .+ Δ, (n-1)*m .+ Δ] .= 1/n * 1/(b-a) .* p[n]
+
+    for i ∈ 0:n-1
+        C₀[i*m .+ Δ, (n-1)*m .+ Δ] .-= b/(b-a) .* p[i]
+        C₁[i*m .+ Δ, (n-1)*m .+ Δ] .-= 1/(b-a) .* p[i]
+    end
+
+#    C₁[Δ, (n-1)*Δ] .= -(n-1) * 1 / (b-a) .* p[0]
+
+    C₀, C₁
+
+end

--- a/build/Interpolating/Lagrange.jl
+++ b/build/Interpolating/Lagrange.jl
@@ -1,0 +1,289 @@
+"""
+    Lagrange{N, S, R, T, X}
+
+Represent a polynomial in Lagrange form using nodes `xs`, weights `ws`, and coefficients `coeffs`.
+The Lagrange form does polynomial interpolation between `xs` and `ys` through `p(x) = Σ_{0..n} ℓ_i(x) y_i`,
+where if `ℓ(x) = prod(x-x_i)`, `w_i = 1/prod_{j≠i}(x_i - x_j)`, then `ℓ_i(x) = ℓ(x) w_i/(x-x_i)`. The `ℓ_i`
+satisfy `ℓ_i(x_j) = δ_{ij}`, so the coefficients are just the `ys`.
+
+```jldoctest Lagrange
+julia> using Polynomials, SpecialPolynomials
+
+julia> p =  Lagrange([1,2,3], [1,2,3])
+Lagrange(1⋅P_0(x) + 2⋅P_1(x) + 3⋅P_2(x))
+
+julia> p.([1,2,3]) # the coefficients
+3-element Vector{Int64}:
+ 1
+ 2
+ 3
+
+julia> convert(Polynomial,  p)
+Polynomials.Polynomial(1.0*x)
+```
+
+The instances hold the nodes and weights, which are necessary for
+representation, so the type alone can not be used for functions such
+as `variable` or `convert(Lagrange, ...)`. For the former we can  use an instance, for the latter we can use `fit`:
+
+```jldoctest Lagrange
+julia> p =  Lagrange([1,2,3], [1,2,3])
+Lagrange(1⋅P_0(x) + 2⋅P_1(x) + 3⋅P_2(x))
+
+julia> variable(p)
+Lagrange(1⋅P_0(x) + 2⋅P_1(x) + 3⋅P_2(x))
+
+julia> q = Polynomial([0,0,1])
+Polynomials.Polynomial(x^2)
+
+julia> qq = fit(Lagrange, p.xs, q)
+Lagrange(1⋅P_0(x) + 4⋅P_1(x) + 9⋅P_2(x))
+
+julia> convert(Polynomial, qq)
+Polynomials.Polynomial(1.0*x^2)
+```
+
+Interpolating polynomials suffer from the Runge phenomenon unless the
+nodes are well chosen. For `P=Chebyshvev` and `P=ChebyshevU`, the
+function `SpecialPolynomials.lagrange_barycentric_nodes_weights(P, n)`
+will return a good choice of `n+1` points over `[-1,1]` along with
+precomputed weights. 
+
+```jldoctest Lagrange
+julia> xs, ws = SpecialPolynomials.lagrange_barycentric_nodes_weights(Chebyshev, 64);
+
+
+julia> f(x) = exp(-x)*sinpi(x)
+f (generic function with 1 method)
+
+julia> p = fit(Lagrange, xs, f.(xs));
+
+
+julia> degree(p)
+64
+
+julia> maximum(abs.(f(x) - p(x) for x in range(-1, 1, length=20))) <= 1e-14
+true
+```
+
+!!! note
+    The above example  is  more directly  done through `fit(Chebyshev, f, 64)`, though  the resulting
+    polynomial will reference a different  basis.
+
+"""
+struct Lagrange{N, S<:Number, R <: Number, T <: Number, X} <: AbstractInterpolatingPolynomial{T,X}
+    xs::Vector{S}
+    ws::Vector{R}
+    coeffs::Vector{T}
+    var::Symbol
+    function  Lagrange(xs::Vector{S}, ws::Vector{R}, coeffs::Vector{T}, var::Symbol=:x) where {S,R,T}
+        xs = unique(xs)
+        N = length(xs)
+        N == length(coeffs) || throw(ArgumentError("the unique xs and the coeffs must have the same length"))
+        new{N, S,R,T,Symbol(var)}(xs, ws, coeffs)
+    end
+    function  Lagrange(xs::Vector{S}, coeffs::Vector{T}, var::Symbol=:x) where {S,T}
+        xs = unique(xs)
+        N = length(xs)
+        ws = lagrange_barycentric_weights(xs)
+        R = eltype(ws)
+        length(coeffs) == length(xs) || throw(ArgumentError("the unique xs and the coeffs must have the same length"))
+        new{N, S, R, T,Symbol(var)}(xs, ws, coeffs)
+    end
+end
+
+export Lagrange
+
+Polynomials.indeterminate(::Type{Lagrange{N,S,R,T,X}}) where {N,S,R,T,X} = X
+basis_symbol(::Type{Lagrange{N,S,R,T}}) where {N,S,R,T} = "ℓ^$(N-1)"
+
+## Boilerplate code reproduced here, as there are three type parameters
+Base.convert(::Type{P}, p::P) where {P <: Lagrange} =  p
+Base.convert(::Type{Lagrange{N,S,R,T}}, p::Lagrange) where {N,S,R,T} = Lagrange{N,S,R,T}(p.xs, p.ws, coeffs(p), p.var)
+Base.promote_rule(::Type{Lagrange{N, S, R, T}}, ::Type{Lagrange{N, S, R, Q}}) where {N, S, R, T, Q <: Number} = Lagrange{N, S, R, promote_type(T,Q)}
+Base.promote_rule(::Type{Lagrange{N, S, R, T}}, ::Type{Q}) where {N, S, R, T, Q <: Number} = Lagrange{N, S, R, promote_type(T,Q)}
+
+
+
+
+
+
+Polynomials.domain(::Type{<:Lagrange}) = Polynomials.Interval(-Inf, Inf)
+function Polynomials.variable(p::Lagrange{S, R, T}, var::Polynomials.SymbolLike=:x) where {S, R, T}
+    _fit(Lagrange, p.xs, p.ws, p.xs, var)
+end
+function Polynomials.one(p::Lagrange)
+    _fit(Lagrange, p.xs, p.ws, ones(eltype(p.xs),length(p.xs)), Polynomials.indeterminate(p))
+end
+Polynomials.zero(p::Lagrange{N, S, R, T}) where {N,S,R,T} = 0*p
+
+##  Evaluation
+##  From https://people.maths.ox.ac.uk/trefethen/barycentric.pdf
+function Polynomials.evalpoly(x, p::Lagrange)
+    ws, xs, cs = p.ws, p.xs, coeffs(p)
+    a = b = zero(x/1)
+    for j in eachindex(xs)
+        Δ = (x - xs[j])
+        iszero(Δ) && return cs[j] # xj ∈ xs, so sum c_j l_i(xj) = sum c_j δ_{ij} = c_j
+        l = ws[j]/Δ
+        a += l * cs[j]
+        b += l
+   end
+   a/b
+end
+(p::Lagrange)(x::Number) = evalpoly(x,p)
+
+## convert to poly
+## avoids division in barycentric form, which isn't available for Polynomial  arguments, such as `x-xs[j]`
+## This has numeric issues, unlike the barycentric form used for evaluation
+function  Base.convert(Q::Type{<:Polynomial},  p::Lagrange{N, S,R,T})  where  {N, S, R, T}
+    q = zero(Q)/1
+    x =  variable(q)
+    xs = p.xs
+    cs = coeffs(p)
+    ws = p.ws
+
+    if length(xs) == 1
+       return cs[1] + 0*x #Polynomial(cs[1]*ones(T,1))
+    else
+        l = fromroots(Polynomial, xs)
+        for i in  eachindex(xs)
+            li = prod(x - xs[j] for j in eachindex(xs) if j != i);
+            q += li * ws[i] * cs[i]
+        end
+    end
+    q
+end
+
+## return w⁻¹s = {1/w_j, 0 <= j <= n} as 1 based ws[j+1] = w_j
+"""
+   lagrange_barycentric_weights(xs)
+
+return [1/w_i for 0 <i <= n] where wi = ∏_{j≠i} (xi - xj)
+"""
+function lagrange_barycentric_weights(xs)
+    n =  length(xs)
+    ws =  ones(eltype(xs), n)
+    for j in 2:n
+        for k in 1:j
+            ws[k] =  (xs[k] - xs[j]) * ws[k]
+        end
+        ws[j] = prod(xs[j]-xs[i] for i in 1:j-1)
+    end
+    1 ./ ws
+end
+
+# https://people.maths.ox.ac.uk/trefethen/barycentric.pdf (5.1)
+function lagrange_barycentric_weights(xs::Union{AbstractRange{T},AbstractUnitRange{T}}) where {T}
+    n = length(xs)-1
+    ws = zeros(float(T), n+1)
+    o = one(T)
+    for j = 0:n
+        ws[1+j] = o * binomial(n, j)
+        o *= -1
+    end
+    ws
+end
+    
+##  add a new point
+## check for  xk ∈ xs?
+"""
+    update_lagrange_barycentric_weights(ws, xs, xn1)
+
+Adds `xn1` to the nodes `xs` and updates the weights `ws` accordingly.
+"""
+function update_lagrange_barycentric_weights(ws, xs, xn1)
+    ys = [wj/(xj - xn1) for (wj,xj) in zip(ws, xs)]
+    wn1 = one(eltype(ws))
+    for xj in xs
+        wn1 *= (xn1 - xj)
+    end
+    push!(ys, 1/wn1)
+    ys
+end
+
+"""
+    lagrange_barycentric_nodes_weights(::Type{<:SpecialPolynomial}, n::Int)
+
+Return a collection of `n+1` nodes and weights the given family of
+polynomials. Defined for `ChebyshevT` and `ChebyshevU` familes, as there
+are `O(n)` algorithms available. Otherwise, `lagrange_barycentric_weights`
+is needed.
+
+
+"""
+lagrange_barycentric_nodes_weights(::Type{<:AbstractSpecialPolynomial}, n::Int) = throw(MethodError())
+
+## can add easily if the nodes are shared
+## otherwise, this needs to interpolate
+function Base.:+(p1::Lagrange{N,S,R,T,X}, p2::Lagrange{M,S1,R1,T1,Y}) where {N,S,R,T,X,M,S1,R1,T1,Y}
+    X == Y || throw(ArgumentError("p1 and p2 must share the same variable"))
+
+    # can just add if using the same set of nodes
+    if N == M && p1.xs == p2.xs
+        cs =  coeffs(p1) +  coeffs(p2)
+        return Lagrange(p1.xs, p1.ws, cs, X)
+    else
+        p,q = N >= M ? (p1, p2) : (p2, p1)
+        xs, ws, cs = p.xs, p.ws, copy(coeffs(p))
+        for i in eachindex(xs)
+            cs[i] += q(xs[i])
+        end
+        return _fit(Lagrange, xs,  ws, cs, X)
+    end
+end
+
+## XXX is there a better way?
+## This refits using  updated weights,
+## but this can be wildly inaccurate
+function Base.:*(p1::Lagrange{N,S,R,T,X}, p2::Lagrange{M,S1,R1,T1,Y}) where {N,S,R,T,X,M,S1,R1,T1,Y}
+
+    X == Y || throw(ArgumentError("p1 and p2 must share the same variable"))
+
+    p, q =  N >= M ? (p1, p2)  : (p2, p1)
+    S2 = typeof(one(S) * one(S1)/1)
+    xs = convert(Vector{S2}, copy(p.xs))
+    ws = copy(p.ws)
+
+    # new_xs ## XXX this is where the work is
+    new_xs = _new_nodes(xs, q.xs)
+    for y in new_xs
+        ws = update_lagrange_barycentric_weights(ws, xs, y)
+        push!(xs, y)
+    end
+    ys = p.(xs) .* q.(xs)
+    _fit(Lagrange, xs,  ws, ys, X)
+
+end
+
+
+# handle scalar case
+function Base.:+(p::Lagrange, c::Number)
+    q = Lagrange(p.xs[1:1], [c], Polynomials.indeterminate(p))
+    p + q
+end
+
+Base.:*(c::Number, p::Lagrange) = p*c
+function Base.:*(p::P, c::Number) where {P <: Lagrange}
+    Lagrange(p.xs, c*coeffs(p),  Polynomials.indeterminate(p))
+end
+
+Base.:-(p::P) where {P<:Lagrange} = (-1)*p
+
+
+
+## short cut if weights are known.
+_fit(P::Type{Lagrange}, xs, ws, ys, var=:x) = Lagrange(xs, ws, ys, var)
+
+function Polynomials.fit(P::Type{<:Lagrange},
+                         xs::AbstractVector{S},
+                         ys::AbstractVector{T};
+                         var = :x) where {S, T}
+    ws = lagrange_barycentric_weights(xs)
+    _fit(P, xs, ws, ys, var)
+end
+
+function Polynomials.fit(P::Type{<:Lagrange}, xs::AbstractVector{S}, f; var=:x) where {S}
+     ws = lagrange_barycentric_weights(xs)
+    _fit(P, xs, ws, f.(xs), var)
+end

--- a/build/Interpolating/Newton.jl
+++ b/build/Interpolating/Newton.jl
@@ -1,0 +1,251 @@
+"""
+    Newton{N,S,T,X}
+
+A [Newton](https://en.wikipedia.org/wiki/Newton_polynomial)
+interpolating polynomial uses a basis `1`, `(x-x_0)`,
+`(x-x_0)(x-x_1)`, ..., `(x-x0)(x-x1)⋅⋅⋅(x-x_{n-1})` and coefficients
+(in forward form) `f[x_0]`, `f[x_0,x_1]`, ...,`f[x_0,...,x_n]`. The
+Newton class stores the nodes (after sorting) and the Newton tableau
+used to generate the coefficients on fitting.
+
+The easiest way to construct an instance is with `fit`, as in:
+
+```jldoctest Newton
+julia> using Polynomials, SpecialPolynomials
+
+julia> xs = [1,2,3,4]; f(x)= x^3 - 2x + 1;
+
+julia> p = fit(Newton, xs, f)
+Newton(5.0⋅p_1(x) + 6.0⋅p_2(x) + 1.0⋅p_3(x))
+
+julia> p.(xs) == f.(xs)  # p interpolates
+true
+
+julia> convert(Polynomial, p)
+Polynomials.Polynomial(1.0 - 2.0*x + 1.0*x^3)
+```
+
+"""
+struct Newton{N, S<:Number, T <: Number, X, V} <: AbstractInterpolatingPolynomial{T, X}
+    xs::Vector{S}
+    tableau::Matrix{T}
+    coeffs::V
+    function Newton(xs::Vector{S}, nt::AbstractMatrix{T}, var::Symbol=:x) where {S,T}
+        N = length(xs)
+        xs = sort(unique(xs))
+        N != length(xs) && throw(ArgumentError("xs must be unique"))
+        v = view(nt, 1, :)
+        new{N,S,T, Symbol(var), typeof(v)}(xs, nt, v)
+    end
+end
+
+export Newton
+
+basis_symbol(::Type{<:Newton}) = "p"
+
+## Boilerplate code reproduced here, as there are two type parameters
+Base.convert(::Type{P}, p::P) where {P <: Newton} =  p
+Base.convert(P::Type{Newton{N,S,T}}, p::Newton) where {N,S,T} = Newton{N,S,T,Polynomial.indeterminate(P,p)}(p.xs, p.tableau)
+Base.promote_rule(::Type{Newton{N, S, T}}, ::Type{U}) where {N, S, T, U <: Number} = Newton{N, S, promote_type(T,U)}
+
+Polynomials.domain(::Type{<:Newton}) = Polynomials.Interval(-Inf, Inf)
+Polynomials.variable(p::Newton{N, S, T}, var::Polynomials.SymbolLike=:x) where {N,S, T} = fit(Newton, p.xs, x -> x, var=var)
+Polynomials.zero(p::Newton{N, S, T}) where {N,S,T} = 0*p
+function Polynomials.one(p::Newton)
+    xs = sort(p.xs)
+    nt = newton_tableau(one, xs)
+    Newton(xs, nt, Polynomials.indeterminate(p))
+end
+
+"""
+    newton_tableau(f, xs::Vector)
+    newton_tableau(xs, ys)
+
+Construct the
+[matrix](https://en.wikipedia.org/wiki/Divided_differences#Matrix_form)
+form of Newton's divided differences. This assumes the xs are unique. 
+
+"""
+newton_tableau(f, xs::AbstractVector{S}) where {S} = newton_tableau(xs, f.(xs)/one(S))
+function newton_tableau(xs::AbstractVector{S}, ys::Vector{T}) where {S,T}
+    xs = sort(unique(xs))
+    n = length(xs)
+    M = diagm(0=>ys/one(S))
+    for i in 2:n
+        for j in 1:n-i+1
+            k = i + j -1
+            M[j, k] = (M[j+1,k] - M[j,k-1]) / (xs[j-1+1+(i-1)] - xs[j-1+1])
+        end
+    end
+    M
+end
+
+"""
+    update_newton_tableau(x, fx, xs, nt)
+
+Update the newton tableau, `nt`, generated from the `xs` for some
+function `f`. The point `(x,fx)` is a new `x` value (from the `xs`)
+and `fx` the function value.
+
+"""
+function update_newton_tableau(x::T, fx::S, xs, nt::Matrix{R}) where {T, S, R}
+    n = size(nt, 1)
+    M = zeros(R, n+1, n+1)
+    for i in 1:n
+        for j in i:n
+            M[i,j] = nt[i,j]
+        end
+    end
+    M[end,end] = fx
+    xxs = vcat(xs, x)
+    for i  in n:-1:1
+        M[i, n+1] = (M[i+1, n+1] - M[i,n]) / (xxs[end] - xxs[end-(n-i+1)])
+    end
+
+    xxs, M
+end
+
+## We use the forward difference formula
+## the coefficients are the top row of the upper
+## triangular tableau
+Polynomials.coeffs(p::Newton) = p.tableau[1,:]
+
+
+
+## Evaluation
+## p(x) = f[x0] + f[x0,x1](x-x0) + ... + f[x0,x1,...,x_n](x-x0)(x-x1)...(x-x_{n-1})
+## use nested evaluation (http://pages.cs.wisc.edu/~amos/412/lecture-notes/lecture08.pdf)
+(p::Newton)(x)  = evalpoly(x,p)
+function Polynomials.evalpoly(x, p::Newton{N}) where {N}
+    xs, cs = p.xs, coeffs(p)
+    tot = cs[end]
+    for j in N-1:-1:1
+        tot = cs[j] + (x - xs[j])*tot
+    end
+    tot
+end
+
+## compute (p,dp)  at x:
+## http://pages.cs.wisc.edu/~amos/412/lecture-notes/lecture08.pdf
+function _dual(p::Newton{N, S,T}, x) where {N,S,T}
+    xs, cs = p.xs, coeffs(p)
+    tot = cs[end]
+    totp = zero(S)
+    for j in N-1:-1:1
+        delta = (x - xs[j])
+        tot, totp = cs[j] + delta * tot, tot + delta * totp
+    end
+    tot, totp
+end
+
+    
+
+function Base.:+(p1::Newton{N,S,T,X}, p2::Newton{M,S1,T1,Y}) where {N,S,T,X,M,S1,T1,Y}
+    X == Y || throw(ArgumentError("p1 and p2 must share the same variable"))
+    if N == M && p1.xs == p2.xs
+        tableau = p1.tableau + p2.tableau
+        return Newton(p1.xs, tableau, X)
+    else
+        p,q = N >= M ? (p1, p2) : (p2, p1)
+        qq = fit(Newton, p.xs, q) # stretch than add
+        ## https://en.wikipedia.org/wiki/Divided_differences
+        ## T_{f+g}x = T_fx + T_gx
+        p + qq
+    end
+
+end
+
+function Base.:*(p1::Newton{N,S,T,X}, p2::Newton{M,S1,T1,Y}) where {N,S,T,X,M,S1,T1,Y}
+    ## Basic idea
+    ## find larger of xs, expand to xxs
+    ## refit p1 and p2 on this
+    ## use  product of tableaus
+    Polynomials.assert_same_variable(p1, p2)
+    p,q = N >= M ? (p1, p2) : (p2, p1)
+    xs = p.xs
+    new_xs = _new_nodes(xs, q.xs)
+
+    xxs = vcat(xs, new_xs)
+    pp = fit(Newton, xxs, p)
+    qq = fit(Newton, xxs, q)
+
+    ## https://en.wikipedia.org/wiki/Divided_differences
+    ## T_{f*g}(x) = T_f(x) * T_g(x)
+
+    Newton(pp.xs, pp.tableau * qq.tableau, X)
+    
+end
+
+## Scalar
+function Base.:+(p::Newton{N,T,S,X}, c::Number) where {N,T,S,X}
+    tableau = copy(p.tableau)
+    for i in 1:N
+        tableau[i,i] += c
+    end
+    Newton(p.xs, tableau, X)
+end
+
+Base.:*(c::Number, p::Newton) = p*c
+function Base.:*(p::P, c::Number) where {P <: Newton}
+    Newton(p.xs, c*p.tableau, Polynomials.indeterminate(p))
+end
+
+Base.:-(p::P) where {P<:Newton} = p*(-1)
+
+
+function  Base.convert(Q::Type{<:Polynomial},  p::Newton{N, S,T})  where  {N,S, T}
+    p(variable(Polynomial{S}))
+end
+
+# return derivative
+# to evaluate derivative at a value
+# use  _dual
+# These are not efficient due to the need to  compute a tableau
+function Polynomials.derivative(p::Newton{N,S,T}, order::Int=1) where {N,S,T}
+    order < 0 && throw(ArgumentError("order must be positive"))
+    order == 0 && return p
+    N==1 &&  return fit(Newton, p.xs, zero)
+    
+    x = variable(Polynomial{S})
+    q,qq = _dual(p, x)
+    dp = fit(Newton, p.xs[1:end-1], qq)
+    if order > 1
+        dp = derivative(dp, order-1)
+    end
+    dp
+    
+end
+
+# integrate
+function Polynomials.integrate(p::Newton{N,S,T}, C::Number=0) where {N,S,T}
+    q = convert(Polynomial, p)
+    Q = integrate(q, C)
+    if length(p.xs) >= 2
+        new_x = p.xs[end] + (p.xs[end] - p.xs[end-1])
+        xxs = vcat(p.xs, new_x)
+    else
+        xxs = vcat(p.xs, p.xs[1]+1)
+    end
+    fit(Newton, xxs, Q, var=Polynomial.indeterminate(p))
+    
+end
+
+
+function Polynomials.fit(P::Type{<:Newton},
+                         xs::Vector{S},
+                         ys::AbstractVector{T};
+                         var = :x,) where {S, T}
+    ind = sortperm(xs)
+    xs = xs[ind]
+    ys = ys[ind]
+    nt = newton_tableau(xs, ys)
+
+    Newton(xs, nt, var)
+end
+
+
+function Polynomials.fit(P::Type{<:Newton}, xs::Vector{S}, f; var=:x) where {S}
+    xs = sort(xs)
+    nt = newton_tableau(f, xs)
+    Newton(xs, nt, var)
+end

--- a/build/Interpolating/interpolating.jl
+++ b/build/Interpolating/interpolating.jl
@@ -1,0 +1,58 @@
+"""
+    AbstractInterpolatingPolynomial{T,X}
+
+Abstract type for interpolating polynomials.
+
+These are polynomial representations of `p(x)` satisfying `p(x_i) =
+y_i` for a specified set of `x` values and `y` values.
+
+For a collection of points `(x_0,y_0), ..., (x_n, y_n)` there is a
+*unique* polynomial of degree `n` or less satisfying
+`p(x_i)=y_i`. This fact allows the specification of `p(x)` using a
+vector of coefficients relative to some set of basis vectors.
+
+The two main types, `Lagrange` and `Newton`, store the nodes within
+the instance. In particular, the type does not contain all the
+information needed to describe the family. So methods like
+`convert(::Type, p)` will not work. Use `fit(Type, xs, p)`, as
+appropriate, instead.
+
+"""
+abstract type AbstractInterpolatingPolynomial{T,X} <: AbstractSpecialPolynomial{T,X} end
+
+
+function Polynomials.showterm(io::IO, ::Type{P}, pj::T, var, j, first::Bool, mimetype) where {N, T, P <: AbstractInterpolatingPolynomial}
+    iszero(pj) && return false
+    !first &&  print(io, " ")
+    print(io, Polynomials.hasneg(T)  && Polynomials.isneg(pj) ? "- " :  (!first ? "+ " : ""))
+    print(io, "$(abs(pj))⋅$(basis_symbol(P))_$(j)($var)")
+    return true
+end
+
+basis_symbol(::Type{<:AbstractInterpolatingPolynomial}) = "P"
+
+function Polynomials.variable(::Type{P}, var::Polynomials.SymbolLike=:x) where {P <: AbstractInterpolatingPolynomial}
+    @warn "No `variable` function is defined for a type, just an instance"
+    throw(MethodError())
+end
+
+
+# pick new nodes for product
+function _new_nodes(xs::Vector{S}, ys::Vector{T}) where {S, T}
+    sort!(ys)
+    n = length(ys)
+    out = setdiff(ys, xs)
+    length(out) >= n-1 && return out[1:n-1]
+    out  = out/1
+    tmp = intersect(xs, ys)
+    sort!(tmp)
+    for i in 2:length(tmp)
+        a,b = tmp[i-1], tmp[i]
+        c = (a+b)/2
+        while c in xs
+            c = (a+c)/2
+        end
+        push!(out, c)
+    end
+    out
+end

--- a/build/Orthogonal/Bessel.jl
+++ b/build/Orthogonal/Bessel.jl
@@ -1,0 +1,91 @@
+## Bessel
+@registerN Bessel AbstractCCOP1 α
+
+
+"""
+    Bessel{α}
+
+Implements the [Bessel](https://dlmf.nist.gov/18.34) polynomials, introduced by [Krall and Frink](https://www.ams.org/journals/tran/1949-065-01/S0002-9947-1949-0028473-1/S0002-9947-1949-0028473-1.pdf) (with `b=2`). The  case `a=2` corresponds to the 
+[Bessel](https://en.wikipedia.org/wiki/Bessel_polynomials) polynomials of Wikipedia. The Bessel  polynomials are not orthogonal over  a domain of the real  line, rather over an arbitray curve in the complex plane enclosing the  origin.  The weight  function is `ρ(x)=(2πi)^(-1)∑Γ(α)/Γ(α+n-1)(-β/x)^n`,   where `β=2`.
+
+```jldoctest
+julia> using Polynomials, SpecialPolynomials
+
+julia> 𝐐 = Rational{Int}
+Rational{Int64}
+
+julia> x = variable(Polynomial{𝐐})
+Polynomials.Polynomial(x)
+
+julia> [basis(Bessel{3//2, 𝐐}, i)(x) for i in 0:5]
+6-element Vector{Polynomial{Rational{Int64}, :x}}:
+ Polynomials.Polynomial(1//1)
+ Polynomials.Polynomial(1//1 + 3//4*x)
+ Polynomials.Polynomial(1//1 + 5//2*x + 35//16*x^2)
+ Polynomials.Polynomial(1//1 + 21//4*x + 189//16*x^2 + 693//64*x^3)
+ Polynomials.Polynomial(1//1 + 9//1*x + 297//8*x^2 + 1287//16*x^3 + 19305//256*x^4)
+ Polynomials.Polynomial(1//1 + 55//4*x + 715//8*x^2 + 10725//32*x^3 + 182325//256*x^4 + 692835//1024*x^5)
+```
+
+"""
+Bessel
+export Bessel
+basis_symbol(::Type{<:Bessel{α}}) where {α} = "Cᵅ"
+Polynomials.domain(::Type{<:Bessel}) = Polynomials.Interval(0, Inf)
+
+abcde(::Type{<:Bessel{α}})  where {α} = NamedTuple{(:a,:b,:c,:d,:e)}((1,0,0,α, 2))
+
+
+function k1k0(::Type{P}, k::Int) where {α, P<:Bessel{α}}
+    k < 0 && return zero(eltype(P))/1
+    iszero(k) && return (one(eltype(P))*α)/2
+
+    val = one(eltype(P))
+    val *=  (2k+α)*(2k+α-1)
+    val /= (k+α-1)*2
+    val
+end
+
+norm2(::Type{<:Bessel{α}}, n) where  {α} = -1^(n + α -1) * Γ(1+n) * 2^(α-1) / (Γ(n  + α -2) *  (2n +  α - 1))
+
+# From https://www.ams.org/journals/tran/1949-065-01/S0002-9947-1949-0028473-1/S0002-9947-1949-0028473-1.pdf we use
+# kn = (n + α - 1)_n / 2^n not (n+α+1)_n/2^n
+# Koepf suggests kn = (n + α + 1)_n/2^n
+function leading_term(P::Type{<:Bessel{α}}, n::Int) where {α}
+    one(eltype(P))/2^n * Pochhammer(n+α-1,n)
+end
+
+weight_function(::Type{<:Bessel{α}}) where {α} = z -> (2π*im)^(-1)*z^(α-2) * exp(-2/z)
+generating_function(::Type{<:Bessel}) = (t, x)  -> error("XXX")
+function classical_hypergeometric(::Type{<:Bessel{α}}, n, x) where {α}
+    as = (-n, n + α - 1)
+    bs = ()
+    pFq(as, bs, -x/2) #/ kn
+end
+
+
+## Overrides XXX fails wih 1 and 2
+function  B̃n(P::Type{<:Bessel{α}}, n::Int) where {α}
+    val =  one(eltype(P))
+    (iszero(n) && α ==  2)  && return val
+    val *=  2*(α - 2)
+    val /= (2*n + α)*(2*n + α - 2)
+    val
+end
+
+function  C̃n(P::Type{<:Bessel{α}}, n::Int) where {α}
+    val = one(eltype(P))
+    n==1 && return -(val*4)/(α^2*(α + 1))
+    
+    val *=  -4*n*(n + α - 2)
+    val /=  (2*n + α - 3)*(2*n + α - 2)^2*(2*n + α - 1)
+    val
+end
+
+#Bn(::Type{<:Bessel{1}}, n::Int, ::Type{S}) where {S} = error("α=1 is not correct")
+#B̃n(P::Type{<:Bessel{2}}, ::Val{0}) where {α} =  one(eltype(P))  # 0  otherwise
+#iszero(N) #?  one(eltype(P)) : zero(eltype(P)))
+#C̃n(P::Type{<:Bessel{α}}, ::Val{1}) where {α} =  -(one(eltype(P))*4)/(α^2*(α + 1))
+
+b̂̃n(::Type{<:Bessel{2}}, n::Int)  = (one(eltype(P)) * 2)/(n*(2n+2))
+b̂̃n(::Type{<:Bessel{2}}, ::Val{0})  = one(eltype(P)) * Inf

--- a/build/Orthogonal/Chebyshev.jl
+++ b/build/Orthogonal/Chebyshev.jl
@@ -442,9 +442,9 @@ julia> derivative(p)
 ChebyshevU(4.0⋅U₀(x) + 12.0⋅U₁(x))
 
 julia> roots(p)
-2-element Vector{ComplexF64}:
- -0.6076252185107651 + 0.0im
- 0.27429188517743175 + 0.0im
+2-element Vector{Float64}:
+ -0.6076252185107651
+  0.27429188517743175
 ```
 """
 ChebyshevU

--- a/build/Orthogonal/Discrete/Charlier.jl
+++ b/build/Orthogonal/Discrete/Charlier.jl
@@ -1,0 +1,28 @@
+@registerN  Charlier AbstractCDOP1 μ
+export  Charlier
+
+
+"""
+    Charlier{μ}
+
+References: [Koekoek and Swarttouw §1.12](https://arxiv.org/pdf/math/9602214.pdf)
+"""
+Charlier
+
+abcde(::Type{<:Charlier{μ}})  where {μ} = NamedTuple{(:a,:b,:c,:d,:e)}((0,1,0,-1,μ))
+
+basis_symbol(::Type{<:Charlier{μ}}) where {μ} = "cᵘ"
+Polynomials.domain(::Type{<:Charlier{μ}}) where {μ} = Polynomials.Interval(0, Inf)
+weight_function(::Type{<:Charlier{μ}}) where {μ} = x  ->  μ^x/gamma(1+x)
+
+
+function k1k0(P::Type{<:Charlier{μ}}, n::Int)  where {μ}
+    -one(eltype(P))/μ
+end
+
+function classical_hypergeometric(P::Type{<:Charlier{μ}}, n::Int, x) where {μ}
+    pFq((-n,-x),(),-1/μ)
+end
+
+    
+    

--- a/build/Orthogonal/Discrete/DiscreteChebyshev.jl
+++ b/build/Orthogonal/Discrete/DiscreteChebyshev.jl
@@ -25,7 +25,7 @@ julia> yᵢ = basis(P, i)
 DiscreteChebyshev(1.0⋅K⁽ᵅᵝ⁾₅(x))
 
 julia> x = variable(P)
-DiscreteChebyshev(-2.0⋅K⁽ᵅᵝ⁾₀(x) + 2.0⋅K⁽ᵅᵝ⁾₁(x))
+DiscreteChebyshev(- 2.0⋅K⁽ᵅᵝ⁾₀(x) + 2.0⋅K⁽ᵅᵝ⁾₁(x))
 
 julia> a,b,c,d,e = SpecialPolynomials.abcde(P)
 (a = 0, b = 0, c = 1, d = 0.5, e = 1)

--- a/build/Orthogonal/Discrete/FallingFactorial.jl
+++ b/build/Orthogonal/Discrete/FallingFactorial.jl
@@ -1,0 +1,196 @@
+# represent the   basis x^(mbar) = x⋅(x-1)⋯(x-m+1) ∈ Πm
+"""
+    FallingFactorial{T}
+
+Construct  a  polynomial with   respect to the basis `x⁰̲,  x¹̲, x²̲, …` where 
+`xⁱ̲ = x  ⋅  (x-1) ⋅  (x-2)  ⋯ (x-i+1)` is the falling Pochhammer  symbol.  See 
+[Falling factorial](https://en.wikipedia.org/wiki/Falling_and_rising_factorials)  for several  facts
+about this  polynomial basis.
+
+In [Koepf and Schmersau](https://arxiv.org/pdf/math/9703217.pdf)
+connection coefficients between the falling factorial polynomial
+system and classical discrete orthogonal polynomials are given.
+
+## Examples
+
+```jldoctest
+julia> using Polynomials, SpecialPolynomials
+
+julia> p = basis(FallingFactorial, 3)
+FallingFactorial(1.0⋅x³̲)
+
+julia> x = variable(Polynomial)
+Polynomials.Polynomial(1.0*x)
+
+julia> p(x) ≈ x*(x-1)*(x-2)
+true
+```
+
+"""
+struct FallingFactorial{T <: Number,X} <: AbstractSpecialPolynomial{T,X}
+    coeffs::Vector{T}
+    function FallingFactorial{T,X}(coeffs::Vector{T}) where {T <: Number,X}
+        length(coeffs) == 0 && return new{T,X}(zeros(T, 1))
+        last_nz = findlast(!iszero, coeffs)
+        last = max(1, last_nz === nothing ? 0 : last_nz)
+        return new{T,X}(coeffs[1:last])
+    end
+    function FallingFactorial{T}(coeffs::Vector{T}, var::Polynomials.SymbolLike=:x) where {T <: Number}
+        FallingFactorial{T,Symbol(var)}(coeffs)
+    end
+
+end
+
+Polynomials.@register FallingFactorial
+export  FallingFactorial
+
+# modified from  Polynomials.unicode_exponent
+function unicode_exponent(io, var, j)
+    print(io, var)
+    a = ("⁻","","","⁰","¹","²","³","⁴","⁵","⁶","⁷","⁸","⁹")
+    for i in string(j)
+        print(io, a[Int(i)-44])
+    end
+end
+
+
+# show as 1⋅(x)₀ + 2⋅(x)₁ + 3⋅(x)₂
+function Polynomials.showterm(io::IO, ::Type{P}, pj::T, var, j, first::Bool, mimetype) where {N, T, P <: FallingFactorial}
+    iszero(pj) && return false
+    !first &&  print(io, " ")
+    print(io, Polynomials.hasneg(T)  && Polynomials.isneg(pj) ? "- " :  (!first ? "+ " : ""))
+    print(io, "$(abs(pj))⋅")
+#    print(io,"$(var)")
+    unicode_exponent(io, var, j)
+    print(io,"̲")
+    return true
+end
+
+
+function  Polynomials.evalpoly(x, p::FallingFactorial)
+    d = degree(p)
+    d <= 0 &&  return  p[0]*one(x)
+
+    xⁱ̲ =  one(x)
+    tot =  p[0]*xⁱ̲
+    for i in  1:d
+        xⁱ̲ *= x-(i-1)
+        tot = muladd(xⁱ̲, p[i], tot)
+    end
+    
+    tot
+end
+
+function Base.one(::Type{P}) where {P<:FallingFactorial}
+    T,X = eltype(P), Polynomials.indeterminate(P)
+    ⟒(P){T,X}(ones(T,1))
+end
+
+function Polynomials.variable(::Type{P}) where {P<:FallingFactorial}
+    T,X = eltype(P), Polynomials.indeterminate(P)
+    ⟒(P){T,X}([zero(T),one(T)])
+end
+
+
+
+k0(P::Type{<:FallingFactorial}) = one(eltype(P))
+
+Base.:*(p::FallingFactorial, q::FallingFactorial) = convert(FallingFactorial,  convert(Polynomial,p)*convert(Polynomial,q))
+
+
+## Connect FallingFactorial with AbstractCDOP
+function Base.convert(::Type{P}, q::Q) where {
+    P <: FallingFactorial,
+    Q <: AbstractCDOP}
+    _convert_cop(P,q)
+end
+function Base.convert(::Type{P}, q::Q) where {
+    P <: AbstractCDOP,
+    Q <: FallingFactorial}
+    _convert_cop(P,q)
+end
+
+##  Koepf and Schmersa Thm 6 connection for P, Q=x^n̲
+function connection_m(::Type{P},::Type{Q},m,n) where {
+    P <: AbstractCDOP,
+    Q <: FallingFactorial}
+
+    a,b,c,d,e = abcde(P)
+
+    c₀ = (a*n + a*m - a + d) * (n - m)
+
+    c₁ = (m+1) * (a*n^2 - 2a*m^2 - a*n - a*m  + n*d - 2d*m  - b*m - d - e)
+
+    c₂ = -(m+1) * (m+2) * (a*m^2 +  2a*m + d*m + b*m + a + d + b + c + e)
+
+    (c₀,c₁,c₂)
+end
+
+
+##  Koepf and Schmersa Thm 7, p25 connection for P=x^n̲, Q
+function connection_m(::Type{P},::Type{Q},m,n) where {
+    P <: FallingFactorial,
+    Q <: AbstractCDOP}
+
+    ā,b̄,c̄,d̄,ē = abcde(Q)
+
+    c₀ =  (2m*ā + ā + d̄)  * (2m*ā +  3ā + d̄) * (2m*ā + 2ā + d̄)^2 * (2m*ā + d̄) * (n - m)
+
+    c₁ =  (2m*ā + ā + d̄)  * (2m*ā +  3ā + d̄) * (2m*ā + 2ā + d̄)  * (m+1)
+    c₁a = 2m^2*n*ā^2  - 2m^2*ā^2
+    c₁a += m^2*ā*d̄ + 2m^2*ā*b̄ + 2m*n*ā^2 + 2m*n*ā*d̄ - 2m*ā^2 - m*ā*d̄ + 2m*ā*b̄ + m*d̄^2
+    c₁a += 2m*d̄*b̄ + n*ā*d̄ +  2n*ā*ē - n*d̄*b̄ -  ā*d̄ + d̄*b̄  + d̄*ē
+    c₁ *= c₁a
+
+    c₂ = (m+1) * (2m*ā + d̄)
+    c₂a = m^4*ā^3 + 4m^3*ā^3 + 2m^3*ā^2*d̄ + 6m^2*ā^3 + 6m*ā^2*d̄
+    c₂a += 4m^2*ā^2*c̄ + 2m^2*ā^2*ē + m^2*ā*d̄^2 - m^2*ā*d̄*b̄ - m^2*ā*b̄^2 + 4m*ā^3 + 6m^2*ā^2*d̄
+    c₂a += 8m*ā^2*c̄ + 4m*ā^2*ē + 2m*ā*d̄^2 - 2m*ā*d̄*b̄ + 4m*ā*d̄*c̄ + 2m*ā*d̄*ē
+    c₂a += -2m*ā*b̄^2 - m*d̄^2*b̄ - m*d̄*b̄^2 + ā^3 + 2ā^2*d̄ +  4ā^2*c̄ + 2ā^2*ē +  ā*d̄^2
+    c₂a += -ā*d̄*b̄  + 4ā*d̄*c̄ + 2*ā*d̄*ē - ā*b̄^2 + ā*ē^2 - d̄^2*b̄ + d̄^2*c̄
+    c₂a += -d̄*b̄^2 - d̄*b̄*ē
+    c₂ *= c₂a * (m+2) *  (m*ā + n*ā + ā + d̄)
+
+    (c₀,c₁,c₂)
+end
+
+
+
+function Base.convert(::Type{P}, q::Q) where {
+    P <: Polynomials.StandardBasisPolynomial,
+    Q <: FallingFactorial}
+    q(variable(P))
+end
+function Base.convert(::Type{P}, q::Q) where {
+    P <: FallingFactorial,
+    Q <: Polynomials.StandardBasisPolynomial}
+    connection(P,q)
+end
+
+
+# stirling of 2nd kind
+@memoize function sterling²(n::Int, k::Int)
+    (iszero(n) && iszero(k)) &&  return 1
+    (iszero(n) || iszero(k)) && return 0
+
+    k*sterling²(n-1,k) + sterling²(n-1, k-1)
+end
+
+# xʲ = ∑ᵢ sterling²(j,i) (x)ᵢ [wikipedia](https://en.wikipedia.org/wiki/Falling_and_rising_factorials)
+function Base.iterate(o::Connection{P, Q}, state=nothing) where {P<:FallingFactorial, Q<:Polynomials.StandardBasisPolynomial}
+    n,k = o.n, o.k
+    if state  == nothing
+        j = k
+    else
+        j = state
+        j += 1
+    end
+    j > n && return nothing
+    val = sterling²(j,k)
+    (j,val), j
+end
+
+
+    
+
+

--- a/build/Orthogonal/Discrete/Hahn.jl
+++ b/build/Orthogonal/Discrete/Hahn.jl
@@ -1,0 +1,47 @@
+@registerN Hahn AbstractCDOP3 α β 𝐍
+export Hahn
+
+"""
+    Hahn{α,β,𝐍}
+
+References: [Koekoek and Swarttouw §1.5](https://arxiv.org/pdf/math/9602214.pdf)
+
+!!! note
+    In  [Koekoek and Swarttouw](https://arxiv.org/pdf/math/9602214.pdf) sections 1.3, 1.4, and 1.6  are other  Hahn-type polynomials,  not  implemented here.
+
+"""
+Hahn
+
+abcde(::Type{<:Hahn{α,β,𝐍}})  where {α,β,𝐍} = NamedTuple{(:a,:b,:c,:d,:e)}((1, -(β+𝐍+1), 0,  α+β+2, -𝐍*(α+1)))
+
+basis_symbol(::Type{<:Hahn{α,β,𝐍}}) where {α,β,𝐍} = "Q⁽ᵅᵝ⁾"
+Polynomials.domain(::Type{<:Hahn{α, β, 𝐍}}) where {α, β,  𝐍} = Polynomials.Interval(0, 𝐍)
+weight_function(::Type{<:Hahn{α,β,𝐍}}) where {α,β,𝐍} = x -> generalized_binomial(α+x,x) * generalized_binomial(𝐍+β-x,𝐍-x)
+
+# use   recurrence relation  1.5.3 of Koekoek and Swarttouw
+# -xQᵢ = AQᵢ₊₁ -  (A+C)Qᵢ + CQᵢ₋₁
+#  or Qᵢ₊₁ = (1/A ⋅ x - (1 + C/A)) Qᵢ + C/A ⋅ Qᵢ₋₁
+# Using kᵢ = A⁻¹ᵢ₋₁ ⋅ A⁻¹ᵢ₋₂ ⋯ A⁻¹₀; so kᵢ₊₁/kᵢ = A⁻¹ᵢ, kᵢ₊₁/kᵢ₋ᵢ = A⁻¹ᵢA⁻¹ᵢ₋₁
+#
+# function Aᵢ⁻¹(n,α,β,𝐍)
+#     num = (2n+α+β + 1) * (2n+α+β+2)
+#     den = (n+α + β + 1)*(n + α + 1) *(𝐍-n)
+#     num/den
+# end
+
+# define kn, k1k_1 through defaults
+function k1k0(P::Type{<:Hahn{α,β, 𝐍}}, n::Int) where {α,β,𝐍}
+
+    num  = (2*n + α + β + 1)*(2*n + α + β + 2)
+    den = (-n + 𝐍)*(n + α + 1)*(n + α + β + 1)
+
+    -(one(eltype(P))*num)/den
+    
+end
+
+# end
+
+function classical_hypergeometric(::Type{<:Hahn{α,β,𝐍}}, n::Int, x)  where {α,β,𝐍}
+    pFq((-n, -x, n+1+α+β),  (α+1, -𝐍),  1)
+end
+

--- a/build/Orthogonal/Discrete/Krawchouk.jl
+++ b/build/Orthogonal/Discrete/Krawchouk.jl
@@ -1,0 +1,43 @@
+@registerN  Krawchouk AbstractCDOP2 p 𝐍
+export  Krawchouk
+
+
+"""
+     Krawchouk{p,𝐍}
+
+Also spelled  Krawtchouk,  Kravhcuk,….
+
+References: [Koekoek and Swarttouw §1.10](https://arxiv.org/pdf/math/9602214.pdf);  see  also  [Coleman](https://arxiv.org/pdf/1101.1798.pdf) for a different  parameterization.
+"""
+Krawchouk
+
+abcde(::Type{<:Krawchouk{p,𝐍}})  where {p,𝐍} = NamedTuple{(:a,:b,:c,:d,:e)}((0, p-1, 0, 1, -p*𝐍))
+
+basis_symbol(::Type{<:Krawchouk{p,𝐍}}) where {p,𝐍} = "kᵖ" * "₍" * sprint(io -> unicode_subscript(io, 𝐍)) * "₎"
+Polynomials.domain(::Type{<:Krawchouk{p,𝐍}}) where {p,𝐍} = Polynomials.Interval(0, 𝐍)
+weight_function(::Type{<:Krawchouk{p,𝐍}})  where {p,𝐍} = x  -> generalized_binomial(𝐍,x)  * p^x * (1-p)^(𝐍-x)
+
+
+function k1k0(P::Type{<:Krawchouk}, n::Int) 
+    one(eltype(P))/(n+1)
+end
+
+
+function classical_hypergeometric(P::Type{<:Krawchouk{p,N}}, n::Int, x) where {p,N}
+    monic = classical_hypergeometric(MonicKrawchouk{p,N},n,x)
+    monic * kn(P,n)
+end
+
+##
+## --------------------------------------------------
+##
+
+@registerN MonicKrawchouk AbstractCDOP2 p 𝐍
+export MonicKrawchouk
+ϟ(::Type{<:MonicKrawchouk{p,𝐍}}) where {p,𝐍} = Krawchouk{p,𝐍}
+ϟ(::Type{<:MonicKrawchouk{p,𝐍,T}}) where {p,𝐍,T} = Krawchouk{p,𝐍,T}
+@register_monic(MonicKrawchouk)
+
+function classical_hypergeometric(P::Type{<:MonicKrawchouk{p,N}}, n::Int, x) where {p,N}
+    Pochhammer( -N,n) * p^n * pFq((-n, -x), -N, 1/p)
+end

--- a/build/Orthogonal/Discrete/Meixner.jl
+++ b/build/Orthogonal/Discrete/Meixner.jl
@@ -1,0 +1,30 @@
+@registerN  Meixner AbstractCDOP2 γ μ
+export  Meixner
+
+"""
+    Meixner{γ,μ}
+
+References: [Koekoek and Swarttouw §1.9](https://arxiv.org/pdf/math/9602214.pdf)
+"""
+Meixner
+
+basis_symbol(::Type{<:Meixner{γ,μ}}) where {γ,μ} = "m⁽ᵞᵝ⁾" 
+Polynomials.domain(::Type{<:Meixner{γ, μ}}) where {γ, μ} = Polynomials.Interval(0, Inf)
+abcde(::Type{<:Meixner{γ,μ}})  where {γ,μ} = NamedTuple{(:a,:b,:c,:d,:e)}((0,1,0,μ-1,γ*μ))
+
+function kn(P::Type{<:Meixner{γ,μ}}, n::Int) where {γ,μ}
+    (1 - 1/μ)^n
+end
+
+function k1k0(P::Type{<:Meixner{γ,μ}}, n::Int) where {γ,μ}
+    (1 - 1/μ)
+end
+function k1k_1(P::Type{<:Meixner{γ,μ}}, n::Int) where {γ,μ}
+    (1 - 1/μ)^(n>0 ? 2 : 1)
+end
+
+function  classical_hypergeometric(P::Type{<:Meixner{γ,μ}}, n::Int,   x) where {γ,μ}
+    Pochhammer(γ,n) * pFq((-n, -x), γ, 1 - 1/μ)
+end
+
+# Overrides

--- a/build/Orthogonal/Discrete/cdop.jl
+++ b/build/Orthogonal/Discrete/cdop.jl
@@ -1,0 +1,230 @@
+# generic classical discrete orthogonal polynomial, CDOP
+
+abstract type AbstractCDOP{T,X,N} <: AbstractCOP{T,X,N} end
+"""
+     AbstractCDOP{T,X,N} <: AbstractCOP{T,X,N}
+
+Following [Koepf  and Schmersau](https://arxiv.org/pdf/math/9703217.pdf), a family `y(x)=p_n(x)=k_x⋅x^n +  ...`  
+for  `n  ∈  {0, 1,…}, k_n ≠ 0` of polynomials is a family of classic *discrete* orthogonal polynomials if it  is  a
+solution of a differential equation
+
+`(a⋅x²+b⋅x+c) ⋅ Δ∇y + (d⋅x + e) ⋅ ∇' + λᵢ⋅ y = 0`,
+
+where  `Δy(x) = y(x+1) - y(x)` and `∇y(x) = y(x) - y(x-1)`.
+
+A family is characterized by the 5 coefficients: `a,b,c,d,e`.
+Let `σ = (a⋅x²+b⋅x+c)`, `τ = (d⋅x + e).`
+
+As in the classical-continuous-orthogonal-polynomial case
+[`AbstractCCOP`](@ref), from these 5 values the cofficients in the
+there-point recursion, and other structural equations can be
+represented. These allow polynomial multiplication, integration,
+differentiation, conversion, etc. to be defined generically.
+
+[Koekoek and Swarttouw](https://arxiv.org/pdf/math/9602214.pdf)
+present an encyclopedia of formula characterizing families of
+orthogonal polynomials. 
+
+For example, on p29 they give  formulas for Hahn polynomials through:
+
+`n(n+α+β+1)y(x) = B(x)y(x+1) -[B(x)+D(x)]y(x) + D(x)y(x-1)`,  with  explicit values  for  `B` and `D`. Reexpressing gives:
+`BΔy(x) - D∇y(x) -λ y(x)  = 0`. From the rexpressed Eqn (4) for Koepf & Schemersau we have the identification:
+`σ+τ =  B; σ=D`,  so  `τ=B-D`. From this `a,b,c,d,e` can be  gleaned.
+
+The above, is termed the eigevalue equation (e.g. [Goertz and Offner](https://arxiv.org/pdf/1609.07291.pdf)), as it can be reexpressed as 
+
+`Δ(D(x)⋅ω(x)⋅∇yᵢ(x) = λᵢ⋅ω(x)⋅yᵢ(x)`
+
+
+
+
+"""
+AbstractCDOP
+
+## Implemented  families
+##                    a     b     c      d      e
+##                    -------------------------------
+## Charlier{μ}        0     1     0     -1      μ
+## Meixner{γ,μ}       0     1     0    μ-1     γ⋅μ
+## Krawchouk{p,𝐍}     0    p-1    0     1      p/𝐍
+## Hahn{α,β,𝐍}        1 -(β+𝐍+1)  0   α+β+2  -𝐍⋅(α+1)
+
+
+# subtypes  to keep track of number of parameters
+# passed to  @registerN macros
+abstract type AbstractCDOP0{T,X,N} <: AbstractCDOP{T,X,N} end
+abstract type AbstractCDOP1{α,T,X,N} <: AbstractCDOP{T,X,N} end
+abstract type AbstractCDOP2{α, β,T,X,N} <: AbstractCDOP{T,X,N}  end
+abstract type AbstractCDOP3{α, β,γ,T,X,N} <: AbstractCDOP{T,X,N}  end
+
+⟒(P::Type{<:AbstractCDOP1{α}}) where {α} = constructorof(P){α}
+⟒(P::Type{<:AbstractCDOP2{α,β}}) where {α, β} = constructorof(P){α, β}
+⟒(P::Type{<:AbstractCDOP3{α,β,γ}}) where {α, β, γ} = constructorof(P){α, β, γ}
+
+# for conversion to base case
+# \upstigma[tab]
+ϛ(P::Type{<:AbstractCDOP}) = FallingFactorial
+
+
+# compose with FallingFactorial
+function Base.convert(::Type{Q}, p::P)  where  {Q <: AbstractCDOP,  P <: AbstractCDOP}
+    T = eltype(P)
+    _convert_cop(Q, _convert_cop(FallingFactorial{T},  p))
+end
+    
+
+Δₓ(p::AbstractCDOP) = p(variable(p)+1)-p(variable(p))
+∇ₓ(p::AbstractCDOP) = p(variable(p))-p(variable(p)-1)
+
+
+function innerproduct(P::Type{<:AbstractCDOP}, f, g)
+    a, b = extrema(P)
+    (isinf(a) || isinf(b)) &&  throw(ArgumentError("Only defined for discrete polynomials  with a finite domain"))
+    ω  = weight_function(P)
+    sum(f(i)*g(i)*ω(i) for i in a:b)
+end
+
+## Structural Equations
+## https://dlmf.nist.gov/18.22
+## we have σ⋅Δ∇p + τ⋅∇p + λp =  0
+## Using parameterization   of  above, τ = C, σ = A - C
+function Ãn(P::Type{<:AbstractCDOP}, a,b,c,d,e, n::Int)
+    one(eltype(P))
+end
+
+function B̃n(P::Type{<:AbstractCDOP}, a,b,c,d,e, n::Int)
+
+    S = eltype(P)
+    
+    num = n*(d + 2b) * (d + a*n - a) + e * (d - 2a)
+    den = (2a*n - 2a   + d )  *  (d + 2a*n)
+
+    iszero(den) && return B̃n(P, Val(n))  
+    
+    val = one(S) * num / den
+    
+    val
+end
+
+function C̃n(P::Type{<:AbstractCDOP}, a,b,c,d,e, n::Int)
+
+    S = eltype(P)
+    
+    num = one(S)
+    num *= (n - 1) * (d + a*n - a)
+    num *= a*n*d - d*b - a*d + a^2*n^2 - 2a^2*n + 4c*a + a^2 + 2e*a - b^2
+    num += -d*b*e + d^2*c + a*e^2
+    
+    num *= (a*n +  d - 2a) * n
+    den = (d - a + 2a*n) * (d + 2a*n - 3a) * (2a*n - 2a + d)^2
+
+    iszero(den) && return C̃n(P, Val(n))
+    
+    val = -one(S) * num  / den
+    
+    val
+end
+
+
+# αn, βn,γn
+# σ⋅pn' = [αn, βn,γn] ⋅ [p_{n+1},p_n,p_{n-1}]
+#αn(P::Type{<:AbstractCDOP}, n::Int) = α̃(P,n) / k1k0(P,n) 
+function α̃n(P::Type{<:AbstractCDOP}, n::Int)
+    a,b,c,d,e = abcde(P)
+    S = eltype(P)
+
+    num = a * n
+    val = one(S) *  num
+    
+    return val
+end
+
+function β̃n(P::Type{<:AbstractCDOP}, n::Int)
+    a,b,c,d,e = abcde(P)
+    S = eltype(P)
+
+    num = -n *  (d  + a*n -  a) * (2*a*n*d - a*d - d*b + 2e*a - 2a^2*n +  2a^2*n^2)
+    den = (2a*n - 2a +  d) * (d + 2a*n)
+
+    iszero(den) &&  return βn(P, Val(n))
+
+    val = (one(S) *  num)  / den
+
+    return val
+end    
+
+
+#γn(P::Type{<:AbstractCDOP}, n::Int) =  γ̃n(P,n) * k1k0(P,n-1)
+function γ̃n(P::Type{<:AbstractCDOP}, n::Int)
+    a,b,c,d,e = abcde(P)
+    S = eltype(P)
+
+    num = (n - 1)  * (d + a*n  - a)
+    num *= (a*n*d - d*b - a*d + a^2*n^2 - 2a^2*n + 4c*a + a^2 + 2e*a - b^2)
+    num += -d*b*e + d^2*c + a*e^2
+    num *= (d + a*n -  a) *  (a*n + d - 2a) * n
+    den = (d - a + 2a*n) * (d + 2a*n - 3a) * (2a*n - 2a + d)^2
+    iszero(den) &&  return γn(P, Val(n))
+    
+    val = one(S) * num / den
+    
+    return val
+end
+
+
+function abcdeᴵ(P::Type{<:AbstractCDOP}) 
+    a,b,c,d,e = abcde(P).a, abcde(P).b, abcde(P).c, abcde(P).d, abcde(P).e
+    NamedTuple{(:a,:b,:c,:d,:e)}((a, b, c, d + 2a, d + e + a + b))
+end
+
+
+function ẫn(P::Type{<:AbstractCDOP}, n::Int)
+    a,b,c,d,e = abcde(P)
+    S = eltype(P)
+    
+    val = one(S)
+    val /= n+1
+    return val
+end
+
+function b̂̃n(P::Type{<:AbstractCDOP}, n::Int)
+    a,b,c,d,e = abcde(P)
+    S = eltype(P)
+    
+    num = -2*a*n * (d + a*n - a) - d*b + a*d - d^2 +2e*a
+    den = (2a*n -  2a  +  d) * (d + 2a*n)
+    iszero(den) && return b̂̃n(P, Val(n))
+
+    val = one(S) * num/ den
+    return val
+    
+end
+
+function ĉ̃n(P::Type{<:AbstractCDOP}, n::Int)
+    a,b,c,d,e = abcde(P)
+    S = eltype(P)
+    
+    num = (n-1)*(d + a*n -a) * (a*n*d  -d*b  -a*d + a^2*n^2 -2a^2*n + 4c*a + a^2 +  2e*a - b^2)
+    num += -d*b*e + d^2*c +  a*e^2
+    num  *=  a*n
+    den = (d - a + 2a*n)  * (d + 2a*n -3a) * (2a*n - 2a  + d)^2
+    iszero(den)  &&  return ĉ̃n(P, Val(n))
+
+    val = (one(S)  *  num) / den
+    return val
+end
+
+
+function ⊗(::Type{<:AbstractCDOP}, p::P, q::Q) where {P <: AbstractCDOP, Q <: AbstractCDOP}
+
+    #@assert  ⟒(P) == ⟒(Q)
+    #@assert eltype(p) == eltype(q)
+    isconstant(p)  && return q * constantterm(p)
+    isconstant(q)  && return p * constantterm(q)    
+    assert_same_variable(p,q)
+        
+    convert(⟒(P), convert(FallingFactorial, p) * convert(FallingFactorial, q))
+
+#    R = eltype(p)
+#    convert(⟒(P){R}, convert(Polynomial, p) * convert(Polynomial, q))
+end

--- a/build/Orthogonal/Discrete/discrete-orthogonal.jl
+++ b/build/Orthogonal/Discrete/discrete-orthogonal.jl
@@ -1,0 +1,143 @@
+##################################################
+
+const ∑ = sum
+
+function innerproduct(P::Type{<:AbstractDiscreteOrthogonalPolynomial}, f, g)
+    dom = domain(P)
+    fn = x -> f(x) * g(x) * weight_function(P)(x)
+    a, b = first(dom), last(dom)
+    if !isinf(a) && !isinf(b)
+        return ∑(fn(x)  for x in first(dom):last(dom))
+    else
+        ## what to do if infinite
+    end
+end
+
+
+
+##
+## --------------------------------------------------
+##
+
+abstract type AbstractDiscreteWeightFunction{T,X,N} <: AbstractDiscreteOrthogonalPolynomial{T,X} end
+abstract type DiscreteWeightFunction{T,X,N} <:  AbstractDiscreteWeightFunction{T,X,N} end
+export DiscreteWeightFunction
+
+"""
+    DiscreteWeightFunction
+
+For a discrete measure, `dλ = ∑ wᵢ δ(x - xᵢ)`, specified through two
+vectors, `xs` and `ws`, a collection of monic orthogonal polynomials is
+produced through Darboux's formula for `α_n` and `β_n` using the
+3-term recurrence defined by `π_{n+1} = (x-α_n)⋅π_n - β_n⋅π_{n-1}` (`An=1`, `Bn=-α_n`, `Cn=β_n`)
+and the discrete Stieltjes method [Guatschi §3.1](https://www.cs.purdue.edu/homes/wxg/Madrid.pdf).
+
+# Example
+
+Discrete Chebyshev by its weight function (uniform  on 0,1,…,N-1)
+
+```jldoctest
+julia> using Polynomials, SpecialPolynomials
+
+julia> const SP = SpecialPolynomials;
+
+julia> N = 9
+9
+
+julia> xs, ws = collect(0:N-1), ones(N);   # w(x) = ∑ wⱼ⋅δ(x-xⱼ)
+
+julia> SP.@register0 DWF DiscreteWeightFunction
+
+julia> SP.@register_discrete_weight_function(DWF, xs, ws)
+
+julia> [SP.Bn.(DWF, 0:N-1) SP.Cn.(DWF, 0:N-1)]
+9×2 Matrix{Float64}:
+ -4.0  9.0
+ -4.0  6.66667
+ -4.0  5.13333
+ -4.0  4.62857
+ -4.0  4.12698
+ -4.0  3.53535
+ -4.0  2.83217
+ -4.0  2.01026
+ -4.0  1.06667
+
+julia> i,j = 3,4; ## check  that ∫pᵢpⱼdw  = 0    for i,j=3,4
+
+julia> sum(basis(DWF,i)(x) *  basis(DWF,j)(x) * w for  (x,w) in zip(xs, ws))
+5.684341886080802e-14
+
+julia> ## Gogin, Hirvensalo (https://doi.org/10.1007/s10958-017-3410-8) characterization
+       D(k,N,x) =  sum((-1)^l * binomial(k+l,k) * binomial(N-l,k-l) *  SP.generalized_binomial(x,l) for l in 0:k)
+D (generic function with 1 method)
+
+julia> x = variable()
+Polynomials.Polynomial(x)
+
+julia> ps,qs = [D(k,N-1,x)  for  k in 0:N-1], [basis(DWF, k)(x) for k  in 0:N-1];
+
+
+
+
+julia> all(qs .* [p[end] for p  in ps] .≈ ps)
+true
+```
+
+"""
+DiscreteWeightFunction
+
+basis_symbol(::Type{<:AbstractDiscreteWeightFunction}) = "W"
+
+xs_ws(::Type{<:AbstractDiscreteWeightFunction}) = throw(ArgumentError("No default method"))
+
+
+# (Gautschi](https://www.cs.purdue.edu/homes/wxg/Madrid.pdf), section 3.1
+# compute α_n = <tπ_n,π_n>/<π_n,π_n>, β_n = <π_n,π_n>/<π_{n-1},π_{n-1}>
+# wherer <p,q> = ∑_1^N w_k p(k) q(k)
+function discrete_stieltjes(W::Type{<:AbstractDiscreteWeightFunction})
+
+    xs,ws = xs_ws(W)
+
+    N  =  length(xs)
+    n = N
+
+    # k = 0 case
+    πk_1, πk = zeros(N), ones(N)
+    
+    βk = β0 = norm_k = sum(ws)/1 # <π_0, π_0> = ∑ w_k 1 ⋅ 1
+    αk = α0 = ∑(ws[k] * xs[k] for k in eachindex(ws)) / norm_k
+    αs = [α0]
+    βs = [β0]
+
+    for _ ∈ 1:(n-1)
+
+        πk1 = (xs .- αk) .* πk - βk * πk_1 # use just computed αk, βk to find π_{k+1} = (x-αk)⋅π_k - βk⋅π_{k-1}
+        norm_k1 =  ∑(ws[k] * πk1[k]^2  for k in eachindex(ws)) # <π_{k+1}, π_{k+1}>
+        
+        # Darboux
+        # α_{k+1} = <x ⋅ π_{k+1}, π_{k+1}> / <π_{k+1}, π_{k+1}>,
+        # β_{k+1} = <π_{k+1}, π_{k+1}> / <π_k, π_k>,
+        αk1 = ∑(ws[k] * xs[k] * πk1[k]^2 for k in eachindex(ws)) / norm_k1
+        βk1 = norm_k1/norm_k
+        
+        push!(αs, αk1)
+        push!(βs, βk1)
+
+        αk, βk = αk1, βk1
+        πk_1, πk = πk, πk1
+        norm_k = norm_k1
+
+    end
+
+    (-αs, βs)
+end
+       
+An(::Type{W}, n) where {W <: AbstractDiscreteWeightFunction} = one(eltype(W))
+
+Bn(::Type{W}, k::Int) where {W <:AbstractDiscreteWeightFunction} = discrete_stieltjes(W)[1][k+1]
+Cn(::Type{W}, k::Int) where {W <:AbstractDiscreteWeightFunction} = discrete_stieltjes(W)[2][k+1]
+
+Polynomials.domain(::Type{<:DiscreteWeightFunction}) = Polynomials.Interval(-Inf, Inf)
+
+innerproduct(W::Type{<:AbstractDiscreteWeightFunction}, f, g) = ∑(wk * f(xk) * g(xk) for (xk, wk) in zip(xs_ws(W)...))
+

--- a/build/Orthogonal/FastLegendre.jl
+++ b/build/Orthogonal/FastLegendre.jl
@@ -1,0 +1,166 @@
+module FastLegendre
+
+# From
+# O(1) Computation of Legendre polynomials and Gauss-Legendre nodes and weights for parallel computing
+# Bogaert, Ignace and Michiels, Bart and Fostier, Jan
+# SIAM JOURNAL ON SCIENTIFIC COMPUTING
+# 34, 2012
+# http://dx.doi.org/10.1137/110855442    
+#
+# as mentioned https://github.com/JuliaMath/SpecialFunctions.jl/issues/124
+#
+# Only Float64
+#
+# Gives a speed up over Clenshaw, which is expected, as this is O(1), not O(n):
+#
+# n= 1000 Clenshaw might be faster
+# n= 10_000 10x faster
+# n= 100_000 10x faster
+# n= 1_000_000 500x faster
+# n= 10_000_000 10,000x faster
+# (measurement of basis(P,n)(x) compared to Basis(P,n)(x)
+
+using FastGaussQuadrature
+using SpecialFunctions
+
+
+# 4 regions of evaluation
+# specialized for Float64 values
+function  fastlegendre(n, x)
+    n == 0 && return one(x)
+    n == 1 && return x
+    n < 100 &&  return  direct_32(n,x)
+    x < 0  &&  return  (iseven(n) ? 1 : -1) * fastlegendre(n,-x)
+    θ = acos(x)
+    (n+1)*sin(θ) > 25 && return asy_32(n,x)
+    asy_33(n,x)
+end
+
+## ---- n < 100 case
+
+# precompute first 99
+const xᵢs = [FastGaussQuadrature.gausslegendre(n)[1][1:(n÷2)] for n in 1:99]
+const xᵢs⁻¹ = [inv.(xᵢ) for xᵢ in xᵢs]
+const xᵢs2⁻¹ = [inv.(1 .- xᵢ.^2) for xᵢ in xᵢs]
+
+# precompute
+const Cn = zeros(Float64, 99)
+Cn[1] = 1.0
+for i in 1:49
+    n = 2i
+    Cn[n]  = sqrt(pi) / gamma(i + 1)  / gamma((1-n)/2)
+    Cn[n+1] = (n+1) * Cn[n]
+end
+
+# use cosine or sine
+function  direct_32(n,x)
+    if abs(x) > 0.707
+        if iseven(n)
+            direct_sine(Val(true), n,x)
+        else
+            direct_sine(Val(false), n,x)
+        end
+    else
+        if iseven(n)
+            direct_cosine(Val(true), n,x)
+        else
+            direct_cosine(Val(false), n,x)
+        end
+    end
+end
+
+
+#x = cos(theta) 1 - x^2 = sintheta0
+function direct_sine(::Val{true}, n,x)
+    tot = one(Float64)
+    xs = xᵢs2⁻¹[n]
+    for aᵢ in xs
+        tot *= 1 - (1-x^2)*aᵢ
+    end
+    tot
+end
+
+direct_sine(::Val{false}, n,x) =  x * direct_sine(Val(true),n,x)
+
+
+function direct_cosine(p::Val{true}, n,x)
+    tot =  Cn[n]
+    xs = xᵢs⁻¹[n]
+    for aᵢ in  xs
+        tot *= (1 - (x*aᵢ)^2)
+    end
+    tot
+end
+direct_cosine(p::Val{false}, n,x) = x * direct_cosine(Val(true), n, x)
+
+
+## ----
+const Cl0s = [gamma(n+1)/gamma(n + 3/2) for n in 1:9]
+τ(x) = evalpoly(1/x, (1/1, 0, -1/64, 0, 21/8192, 0, -671/524288, 0, 180323/80323134, 0,
+                    -20898423/8589934592, - 7426362705/1099511627776))
+
+function Cl0(l)
+    1 <= l < 10 && return Cl0s[l]
+    1/sqrt(l+3/4)*τ(l+3/4)
+end
+
+function asy_32(n,x)
+    M = 17 
+    θ = acos(x) 
+    val = sqrt((2/pi)*(1/sin(θ))) 
+    tot = 0.0
+    sθ = sin(θ)
+    λ = Cl0(n)
+    for m in 0:M-1
+        α = (n+m+1/2)*θ - (m+1/2)*pi/2
+        tot += λ * cos(α)
+        λ *= (m+1/2)^2/2/(m+1)/(n+m+3/2) / sθ
+    end
+    val * tot
+end
+
+## ---
+h(n,y) = y^n * besselj(n,y)
+
+const cns = [[1/8, -1/12],
+      [11/384, -7/160, 1/160],
+      [173/15360, -101/3584, 671/80640, -61/120960],
+      [22931/3440640,  -90497/3870720, 217/20480, -1261/967680, 1261/29030400],
+      [1319183/247726080, -10918993/454164480, +1676287/113541120, -7034857/2554675200,
+       +1501/8110080, -79/20275200],
+      [233526463/43599790080, -1396004969/47233105920, +2323237523/101213798400,
+       -72836747/12651724800, +3135577/5367398400, -1532789/61993451520, +66643/185980354560]
+      ]
+
+function fn(i,y)
+    n = 2i
+    cs = cns[i]
+    tot = 0.0
+    Δ = i-1
+    for j in i:2i
+        tot += cs[j-Δ]*h(j,y)
+    end
+    tot
+end
+    
+
+function asy_33(n,x)
+    v = n + 1/2
+    θ = acos(x)
+    y = v * θ
+
+    # Eq (3.19)
+    val = besselj(0,y)
+
+    
+    λ = 1/v^2
+    for i in 1:6
+        val += fn(i,y)*λ
+        λ /= v^2
+    end
+    val
+
+    
+end
+
+end

--- a/build/Orthogonal/Gegenbauer.jl
+++ b/build/Orthogonal/Gegenbauer.jl
@@ -1,0 +1,75 @@
+## Gegenbauer Polynomials
+@registerN Gegenbauer AbstractCCOP1 α
+export  Gegenbauer
+
+"""
+   Gegenbauer{α, T <: Number}
+
+The Gegenbauer polynomials have weight function
+`(1-x^2)^(α-1/2)` over the domain `[-1,1]`. The parameter `α` is
+specified in the constructor. These are also called the ultra-spherical polynomials.
+The Legendre polynomials are the specialization  `Gegenbauer{1/2}`.
+
+```jldoctest
+julia> using Polynomials, SpecialPolynomials
+
+julia> p =  Gegenbauer{1/2}([1,2,3])
+typename(Gegenbauer){0.5}(1⋅Cᵅ₀(x) + 2⋅Cᵅ₁(x) + 3⋅Cᵅ₂(x))
+
+julia> convert(Polynomial, p)
+Polynomials.Polynomial(-0.5 + 2.0*x + 4.5*x^2)
+```
+
+"""
+Gegenbauer
+
+
+basis_symbol(::Type{<:Gegenbauer{α}}) where {α} = "Cᵅ"
+Polynomials.domain(::Type{<:Gegenbauer{α}}) where {α} = Polynomials.Interval(-1,1)
+
+abcde(::Type{<:Gegenbauer{α}})  where {α} = NamedTuple{(:a,:b,:c,:d,:e)}((-1,0,1,-(2α+1),0))
+
+k0(P::Type{<:Gegenbauer}) = one(eltype(P))
+k1k0(P::Type{<:Gegenbauer{α}}, k::Int) where {α} =(one(eltype(P))*2*(α+k))/(k+1)
+
+function norm2(::Type{<:Gegenbauer{α}}, n) where{α}
+    pi * 2^(1-2α) * gamma(n + 2α) / (gamma(n+1) * (n+α) * gamma(α)^2)
+end
+function ω₁₀(::Type{<:Gegenbauer{α}}, n) where{α}
+    val = gamma(n + 1 + 2α) / gamma(n + 2α)
+    val /= (n+1)
+    val *= (n + α)/(n+1+α)
+    sqrt(val)
+
+end
+
+weight_function(::Type{<:Gegenbauer{α}}) where {α} = x -> (1-x^2)^(α-1/2)
+generating_function(::Type{<:Gegenbauer{α}}) where {α} = (t,x) -> begin
+    1/(1-2x*t +t^2)^α
+end
+function classical_hypergeometric(::Type{<:Gegenbauer{α}}, n, x) where {α}
+    (α > -1/2 && !iszero(α)) || throw(ArgumentError("α > -1/2 and α ≠ 0 is necessary"))
+
+    as = (-n, 2α+n)
+    bs = (α + 1/2,)
+    return Pochhammer_factorial(2α,n) * pFq(as, bs, (1-x)/2)
+          
+end
+
+
+
+# overrides; big speedup if we avoid generating  from  a,b,c,d,e
+B̃n(P::Type{<:Gegenbauer{α}}, n::Int) where {α} = zero(eltype(P))
+C̃n(P::Type{<:Gegenbauer{α}}, n::Int) where {α} = (one(eltype(P))*n*(n + 2*α - 1))/(4*(n^2 + 2*n*α - n + α^2 - α))
+b̂̃n(P::Type{<:Gegenbauer{α}}, n::Int) where {α} = zero(eltype(P))# one(S) *  4/α/(α+2)
+b̂̃n(P::Type{<:Gegenbauer{α}}, ::Val{N}) where {α,N} = zero(eltype(P))# one(S) *  4/α/(α+2) 
+ĉ̃n(P::Type{<:Gegenbauer{α}}, ::Val{0}) where {α} = zero(eltype(P)) #one(S) *  4/α/(α+2) 
+
+
+
+
+@registerN OrthonormalGegenbauer AbstractCCOP1 α
+export OrthonormalGegenbauer
+ϟ(::Type{<:OrthonormalGegenbauer{α}}) where {α} = Gegenbauer{α}
+ϟ(::Type{<:OrthonormalGegenbauer{α,T}}) where {α,T} = Gegenbauer{α,T}
+@register_orthonormal(OrthonormalGegenbauer)

--- a/build/Orthogonal/Hermite.jl
+++ b/build/Orthogonal/Hermite.jl
@@ -1,0 +1,290 @@
+## Hermite
+@register0 Hermite AbstractCCOP0
+export Hermite
+
+
+
+"""
+    Hermite
+
+The [Hermite](https://en.wikipedia.org/wiki/Hermite_polynomials) polynomials have two versions the physicists (`Hermite`  or  `H`) and the probablalists (`ChebyshevHermite` or  `Hₑ`). They are  related through  `Hᵢ(x) =  2^(i/2) Hₑᵢ(√2 x)`.
+
+The Hermite   polynomials have weight  function `w(x)=exp(-x^2/2)` and domain the real line.
+
+## Examples
+```jldoctest
+julia> using Polynomials,  SpecialPolynomials
+
+julia> x = variable(Polynomial{Rational{Int}})
+Polynomials.Polynomial(x)
+
+julia> [basis(Hermite, i)(x) for i in 0:5]
+6-element Vector{Polynomial{Float64, :x}}:
+ Polynomials.Polynomial(1.0)
+ Polynomials.Polynomial(2.0*x)
+ Polynomials.Polynomial(-2.0 + 4.0*x^2)
+ Polynomials.Polynomial(-12.0*x + 8.0*x^3)
+ Polynomials.Polynomial(12.0 - 48.0*x^2 + 16.0*x^4)
+ Polynomials.Polynomial(120.0*x - 160.0*x^3 + 32.0*x^5)
+
+julia> [basis(ChebyshevHermite, i)(x) for i in 0:5]
+6-element Vector{Polynomial{Float64, :x}}:
+ Polynomials.Polynomial(1.0)
+ Polynomials.Polynomial(1.0*x)
+ Polynomials.Polynomial(-1.0 + 1.0*x^2)
+ Polynomials.Polynomial(-3.0*x + 1.0*x^3)
+ Polynomials.Polynomial(3.0 - 6.0*x^2 + 1.0*x^4)
+ Polynomials.Polynomial(15.0*x - 10.0*x^3 + 1.0*x^5)
+```
+
+!!! note
+    The Hermite family needs help, as the computed values for `Bn`,and,`Cn` are  both 0.
+"""
+Hermite
+
+
+basis_symbol(::Type{<:Hermite}) = "H"
+Polynomials.domain(::Type{<:Hermite}) = Polynomials.Interval(-Inf, Inf)
+
+abcde(::Type{<:Hermite})  = NamedTuple{(:a,:b,:c,:d,:e)}((1,0,0,-2,0))
+
+k0(P::Type{<:Hermite}) = one(eltype(P))
+function k1k0(P::Type{<:Hermite}, k::Int)
+    val = 2*one(eltype(P))
+    val
+end
+
+norm2(::Type{<:Hermite}, n) = sqrt(pi) * 2^n * gamma(n+1)
+weight_function(::Type{<: Hermite})  = x -> exp(-x^2)
+generating_function(::Type{<:Hermite}) = (t, x)  -> exp(2*t*x - t^2)
+function classical_hypergeometric(::Type{<:Hermite}, n, x)
+    as = iseven(n) ? (-n ÷ 2, -(n-1)/2) : (-n/2, -(n-1)÷2)
+    bs = ()
+    (2x)^n * pFq(as, bs, -inv(x)^2)
+end
+
+gauss_nodes_weights(p::Type{P}, n) where {P <: Hermite} =
+    FastGaussQuadrature.gausshermite(n)
+
+
+## Overrides
+# Use override here, as we get  An,Bn,Cn =  1, 0,0, otherwise
+An(P::Type{<:Hermite}, n::Int) = 2*one(eltype(P))
+Bn(P::Type{<:Hermite}, n::Int) = zero(eltype(P))
+Cn(P::Type{<:Hermite}, n::Int) = 2*n*one(eltype(P))
+
+β̃n(P::Type{<:Hermite},  n::Int) = zero(eltype(P))
+γ̃n(P::Type{<:Hermite},  n::Int) = zero(eltype(P))
+b̂̃n(P::Type{<:Hermite}, ::Val{N}) where {N} = zero(eltype(P)) #where {M} = error("Don't call me")#zero(S)
+ĉ̃n(P::Type{<:Hermite}, ::Val{N}) where {N}  = zero(eltype(P)) #where {M} = error("Don't call me")#zero(S)
+
+## https://arxiv.org/pdf/1901.01648.pdf. Connection formula (14)
+##  x^n  = n! sum(H_{n-2j}/ (2^j(n-2j)!j!) j = 0:floor(n/2))
+
+Base.convert(P::Type{<:Hermite}, q::Polynomial) = connection(P,q)
+function Base.iterate(o::Connection{P, Q}, state=nothing) where
+    {P<:Hermite,
+     Q<:Polynomials.StandardBasisPolynomial}
+
+    k, n = o.k, o.n
+
+    if state == nothing
+        i = k
+        j = 0
+        i > n && return nothing
+        val = __hermite_lambda(i,k)
+    elseif state[1] + 2 > n # terminate
+        return nothing
+    else
+        j,val1 = state
+        #val1 *= (i+1)*(i+2)/4/(j+1/4)
+        j += 1
+        i = k + 2j
+        val = __hermite_lambda(i,k)
+    end
+
+    return(i, val), (j, val)
+end
+
+function __hermite_lambda(n,k)
+    val = gamma(1+n)/2^n
+    val /= gamma(1+k)
+    val /= gamma(1 + (n-k)/2)
+    val
+end
+
+
+# 2x more performant
+function Polynomials.integrate(p::P, C::Number=0) where {T,X,P<:Hermite{T,X}}
+    # int H_n = 1/(n+1) H_{n+1}
+    R = eltype(one(T)/1)
+    d = degree(p)
+    qs = zeros(R, d+2)
+
+    for i in 0:d
+        qs[i+2] = p[i]/(2(i+1))
+    end
+
+    q = ⟒(P){R,X}(qs)
+    q = q - q(0) + R(C)
+
+    return q
+end
+
+##
+## --------------------------------------------------
+##
+
+@register0 MonicHermite AbstractCCOP0
+export MonicHermite
+ϟ(::Type{<:MonicHermite}) = Hermite
+ϟ(::Type{<:MonicHermite{T}}) where {T} = Hermite{T}
+@register_monic(MonicHermite)
+
+pqr_start(::Type{<:MonicHermite}) = 0
+pqr_symmetry(::Type{<:MonicHermite}) = true
+pqr_weight(P::Type{<:MonicHermite}, n, x, dπx) = (one(P)*2)*exp(-x^2)/(dπx*dπx)
+
+
+
+
+
+##
+## --------------------------------------------------
+##
+@register0 ChebyshevHermite AbstractCCOP0
+export ChebyshevHermite
+"""
+    ChebyshevHermite
+
+Type for the Probabalist's  [Hermite](https://en.wikipedia.org/wiki/Hermite_polynomials) polynomials.
+
+"""
+ChebyshevHermite
+
+basis_symbol(::Type{<:ChebyshevHermite}) = "Hₑ"
+Polynomials.domain(::Type{<:ChebyshevHermite}) = Polynomials.Interval(-Inf, Inf)
+
+# https://arxiv.org/pdf/1901.01648.pdf eqn 17
+abcde(::Type{<:ChebyshevHermite})  = NamedTuple{(:a,:b,:c,:d,:e)}((0,0,1,-1,0))
+
+kn(P::Type{<:ChebyshevHermite}, n::Int) =  one(eltype(P))
+k1k0(P::Type{<:ChebyshevHermite}, k::Int)  = one(eltype(P))
+k1k_1(P::Type{<:ChebyshevHermite}, k::Int) =  one(eltype(P))
+ismonic(::Type{<:ChebyshevHermite}) = true
+
+weight_function(P::Type{ChebyshevHermite})  = x -> exp(-(one(eltype(P))*x^2)/2)
+generating_function(::Type{<:ChebyshevHermite}) = (t, x)  -> exp(t*x - t^2/2)
+function classical_hypergeometric(::Type{<:ChebyshevHermite}, n, x)
+    2^(-n/2)*classical_hypergeometric(Hermite, n,  x/sqrt(2))
+end
+
+
+function  gauss_nodes_weights(P::Type{<:ChebyshevHermite}, n)  where {α,β}
+    xs, ws = glaser_liu_rokhlin_gauss_nodes(basis(ChebyshevHermite, n))
+    xs, ws
+end
+
+pqr_start(::Type{<:ChebyshevHermite}) = 0
+pqr_symmetry(::Type{<:ChebyshevHermite}) = true
+pqr_weight(P::Type{<:ChebyshevHermite}, n, x, dπx) =  sqrt(2)*gamma(1+n)*sqrt(pi)/(dπx)^2
+
+
+## Overrides
+#An(P::Type{<:ChebyshevHermite}, n::Int) = one(eltype(P))
+#Bn(P::Type{<:ChebyshevHermite}, n::Int) = zero(eltype(P))
+#Cn(P::Type{<:ChebyshevHermite}, n::Int) = -one(eltype(P))*n
+
+##
+## --------------------------------------------------
+##
+
+##  Multiplication
+## TODO: work  on  types
+AbstractHermite{T,X} = Union{Hermite{T,X}, ChebyshevHermite{T,X}}
+
+# Default is slow. Instead
+# directly use a linearization formula from
+# https://arxiv.org/pdf/1901.01648.pdf
+# and  for Hermite, Hn(x) =2^(n/2)Hₑ_n(sqrt(2) x)
+# so Hm⋅Hn = ∑ C_{m,n,j} 2^j H_{m+n-2j}
+function ⊗(::Type{<:AbstractHermite}, p::P, q::Q) where {T,X,S,Y, P<:AbstractHermite{T,X}, Q<:AbstractHermite{S,Y}}
+    R = eltype(one(promote_type(T,S))/1)
+    N,M = degree(p), degree(q)
+    N == -1 && return zero(⟒(P){R,Y})
+    M == -1 && return zero(⟒(P){R,X})
+    N == 0  && return q * p[0]
+    M == 0  && return p * q[0]
+    X != Y && throw(ArgumentError("Variable names must match"))
+
+    as =  zeros(R, 1+N+M)
+    for i  in eachindex(p)
+        pᵢ = p[i]
+        iszero(pᵢ) && continue
+        for  j in eachindex(q)
+            qⱼ = q[j]
+            pᵢqⱼ = pᵢ*qⱼ
+            iszero(qⱼ) &&  continue
+            λᵤ = one(R)
+            for  k in 0:min(i,j)
+                as[1 + i  +  j - 2k] += pᵢqⱼ * λᵤ 
+                λᵤ *= (i-k) * (j-k) / (k+1) * hermite_α(P)
+            end
+        end
+    end
+    ⟒(P){R,X}(as)
+end
+                    
+hermite_α(P::Type{<:ChebyshevHermite}) = 1
+hermite_α(P::Type{<:Hermite}) = 2 
+
+#⊗(p::Hermite, q::Hermite) = linearization_product(p, q)
+#⊗(p::ChebyshevHermite, q::ChebyshevHermite) = linearization_product(p, q)
+
+# function Base.iterate(o::Linearization{P,R}, state =  nothing) where {P <: AbstractHermite,R}
+
+#     l, m, n = o.l, o.m, o.n
+#     l  > m + n && return nothing
+    
+#     if state == nothing
+
+#         #k =  0
+#         j = 0
+#         p = min(l, n)
+#         q = l - p
+#         val = linearization_α(P, R, j, l, p, q) 
+
+#     else
+#         # we work with l + 2j as there is a parity consideration
+#         j, p, q, val  = state
+#         s = l + j # l +2j + p + q = l +2j + l = 2l + 2j, so s=l+j
+#         if p == 0 ||  q == m || q  > s
+#             j += 1
+#             l + 2j > n+m && return nothing #  l + 2j  is too  big now
+#             p = min(l + j, n)  # p <= s
+#             q = l + 2j - p
+#             q > s + 1 && return nothing
+#             val = linearization_α(P, R, j, l, p, q)
+#         else
+#             p -= 1
+#             q += 1
+
+#             λ = q/(p+1)*(s-(q-1))/(s-p)            
+#             val *= λ
+#         end
+
+#     end
+                
+#     return (p,q,val), (j, p, q, val)
+# end
+
+
+# #  https://arxiv.org/pdf/1901.01648.pdf equation (74)
+# function linearization_α(P::Type{<:AbstractHermite}, R, j, l, n, m)
+#     s = l + j # pass in j to avoid s = divrem(l + m + n,  2) call
+#     val = one(R)
+#     val *= gamma(1+m)*gamma(1+n)/gamma(1+s-m)/gamma(1+s-n)/gamma(1+s-l)
+#     val *= linearization_λ(P, l, m,n)
+# end
+# linearization_λ(::Type{<:Hermite}, l, m, n) = 2.0^((m+n-l)/2)
+# linearization_λ(::Type{<:ChebyshevHermite}, l, m, n) = 1    

--- a/build/Orthogonal/Jacobi.jl
+++ b/build/Orthogonal/Jacobi.jl
@@ -1,0 +1,149 @@
+## Jacobi Polynomials
+@registerN Jacobi AbstractCCOP2 α β
+export Jacobi
+
+"""
+    Jacobi{α,  β, T}
+
+Implements the [Jacobi](https://en.wikipedia.org/wiki/Jacobi_polynomials) polynomials. These have weight function `w(x) = (1-x)^α ⋅ (1+x)^β` over the domain `[-1,1]`. Many orthogonal polynomial types are special cases. The parameters are  specified to the constructors:
+
+```jldoctest
+julia> using Polynomials, SpecialPolynomials
+
+julia> p = Jacobi{-1/2, -1/2}([0,0,1])
+typename(Jacobi){-0.5,-0.5}(1⋅Jᵅᵝ₂(x))
+
+julia> convert(Polynomial, p)
+Polynomials.Polynomial(-0.375 + 0.75*x^2)
+
+julia> monic(p) = (q=convert(Polynomial,p); q/q[end])
+monic (generic function with 1 method)
+
+julia> monic(p) ≈  monic(basis(Chebyshev, 2))
+true
+
+```
+
+"""
+Jacobi
+
+basis_symbol(::Type{<:Jacobi{α,β}}) where {α,β} = "Jᵅᵝ"
+Polynomials.domain(::Type{<:Jacobi{α, β}}) where {α, β} =
+    Polynomials.Interval{β >= 0 ? Open : Closed, α >= 0 ? Open : Closed}(-1, 1)
+abcde(::Type{<:Jacobi{α,β}})  where {α,β} = NamedTuple{(:a,:b,:c,:d,:e)}((-1,0,1,-(α+β+2),β-α))
+
+k0(P::Type{<:Jacobi}) = one(eltype(P))
+function k1k0(P::Type{<:Jacobi{α,β}}, n::Int) where {α,β}
+    n == -1  &&  return one(eltype(P))/1 
+    γ = 2n + α + β
+    val = one(eltype(P))
+    if n == 0
+        val *= (α+β)/2 + 1
+    else
+        num = (γ + 1) * (γ + 2)
+        den = 2 * (n+1) * (γ - n + 1)
+        iszero(den) && return k1k0(P, Val(n))
+        val *= num / den
+    end
+    val
+end
+
+#kn =  1/2^n ⋅ choose(2n+α+β, n) = (2n+α+β)_n / (2^b  n!)
+function leading_term(P::Type{<:Jacobi{α,β}}, n::Int) where {α,β}
+    a = α+β+n+1
+    nn = n
+    tot = one(eltype(P))/1
+    for i in 0:n-1
+        tot *= a/(2*nn)
+        a += 1
+        nn -= 1
+    end
+    tot
+    
+end
+
+
+weight_function(::Type{<:Jacobi{α, β}}) where {α, β} = x -> (1-x)^α *  (1+x)^β
+generating_function(::Type{<:Jacobi{α, β}}) where {α, β} = (t,x) -> begin
+    R = sqrt(1 - 2x*t+t^2)
+    2^(α + β) * 1/R  * (1 - t + R)^(-α) * (1 + t + R)^(-β)
+end
+
+"""
+    jacobi_eval(α, β, n, z)
+
+Evaluate the nth basis element of Pᵅᵝ at z using
+
+`Pₙᵅᵝ(z) = 2⁻ⁿ∑ (α+n, k) × (β+n, n-k) ⋅ (z+1)ᵏ ⋅ (z-1)ⁿ⁻ᵏ`
+
+This alternate evaluation is  useful when α or β ≤ -1 (and consequently the polynomials are not orthogonal)
+"""
+function jacobi_eval(α, β, n, z)
+    T = eltype(z/2)
+    tot = zero(T)
+    for k in 0:n
+        tot += generalized_binomial′(α+n,k) * generalized_binomial′(β+n, n-k) * ((z+1)/2)^k * ((z-1)/2)^(n-k)
+    end
+    tot
+end
+
+
+# gauss_nodes_weights(p::Type{P}, n) where {α, β, P <: Jacobi{α, β}} =
+#     FastGaussQuadrature.gaussjacobi(n, α, β)
+
+function classical_hypergeometric(::Type{<:Jacobi{α, β}}, n, x) where {α,β}
+
+    (α ≤ -1 || β ≤ -1) && throw(ArgumentError("α and β must be > -1"))
+    
+    as = (-n, n+α+β+1)
+    bs = (α+1,)
+    
+    Pochhammer_factorial(α+1,n) * pFq(as, bs, (1 - x)/2)
+end
+
+
+
+function norm2(::Type{<:Jacobi{α, β}}, n) where{α, β}
+    α > -1 && β > -1 || throw(ArgumentError("α, β > -1 is necessary"))
+    2^(α+β+1)/(2n+α+β+1) * (Γ(n+α+1) *  Γ(n + β +1))/(Γ(n+α+β+1)*Γ(n+1))
+end
+function ω₁₀(::Type{<:Jacobi{α, β}}, n) where{α, β}
+    val = Γ(n+1+α+1)/Γ(n+α+1)
+    val *= Γ(n + 1+ β +1) / Γ(n + β +1)
+    val *= Γ(n+α+β+1) / Γ(n+1+α+β+1)
+    val *= Γ(n+1) / Γ(n+1+1)
+    val *= (2n+α+β+1) / (2(n+1)+α+β+1)
+    sqrt(val)
+end
+
+# overrides
+B̃n(P::Type{<:Jacobi{α,β}}, ::Val{0}) where {α, β} = iszero(α+β) ? (α-β)*one(eltype(P))/2 : (α-β)*one(eltype(P))/(2(α+β+2))
+C̃n(P::Type{<:Jacobi{α,β}}, ::Val{1}) where {α,β} = -one(eltype(P)) * ((α - β)^2 - (α + β + 2)^2)/((α + β + 2)^2*(α + β + 3))
+
+b̂̃n(P::Type{<:Jacobi{α,β}}, ::Val{0}) where {α,β} = one(eltype(P)) * NaN
+ĉ̃n(P::Type{<:Jacobi}, ::Val{0})  = zero(eltype(P))
+ĉ̃n(P::Type{<:Jacobi{α,β}}, ::Val{1}) where {α,β} = one(eltype(P)) * ((α - β)^2 - (α + β + 2)^2)/((α + β + 1)*(α + β + 2)^2*(α + β + 3))
+
+
+
+
+##
+## --------------------------------------------------
+##
+
+@registerN MonicJacobi AbstractCCOP2 α β
+export MonicJacobi
+ϟ(::Type{<:MonicJacobi{α,β}}) where {α,β} = Jacobi{α,β}
+ϟ(::Type{<:MonicJacobi{α,β,T}}) where {α,β,T} = Jacobi{α,β,T}
+
+@register_monic(MonicJacobi)
+
+
+@registerN OrthonormalJacobi AbstractCCOP2 α β
+export OrthonormalJacobi
+ϟ(::Type{<:OrthonormalJacobi{α,β}}) where {α,β} = Jacobi{α,β}
+ϟ(::Type{<:OrthonormalJacobi{α,β,T}}) where {α,β,T} = Jacobi{α,β,T}
+
+@register_orthonormal(OrthonormalJacobi)
+
+

--- a/build/Orthogonal/Laguerre.jl
+++ b/build/Orthogonal/Laguerre.jl
@@ -1,0 +1,126 @@
+@registerN Laguerre AbstractCCOP1 α
+export  Laguerre
+
+"""
+   Laguerre{α, T <: Number}
+
+The  Laguerre polynomials have weight function `x^α * exp(-x)` over the domain `[0, oo)`. The parameter `α` is specified through the constructor.
+
+```jldoctest
+julia> using Polynomials, SpecialPolynomials
+
+julia> p = Laguerre{1/2}([1,2,3])
+typename(Laguerre){0.5}(1⋅Lᵅ₀(x) + 2⋅Lᵅ₁(x) + 3⋅Lᵅ₂(x))
+
+julia> convert(Polynomial, p)
+Polynomials.Polynomial(9.625 - 9.5*x + 1.5*x^2)
+```
+
+The Laguerre polynomials are the case `α=0`.
+
+```jldoctest
+julia> using Polynomials, SpecialPolynomials
+
+julia> p = Laguerre{0}([1,2,3])
+typename(Laguerre){0}(1⋅L₀(x) + 2⋅L₁(x) + 3⋅L₂(x))
+
+julia> convert(Polynomial, p)
+Polynomials.Polynomial(6.0 - 8.0*x + 1.5*x^2)
+
+julia> phi(u, i) = derivative(u) -  u # verify Rodrigues' formula for small n; n! L_n = (d/dx-1)^n x^n
+phi (generic function with 1 method)
+
+julia> x = Polynomial(:x)
+Polynomials.Polynomial(1.0*x)
+
+julia> n = 7
+7
+
+julia> factorial(n) * basis(Laguerre{0}, n) - foldl(phi, 1:n, init=x^n)
+Polynomials.Polynomial(-5.4569682106375694e-12 + 1.4551915228366852e-11*x - 7.275957614183426e-12*x^2)
+```
+
+
+"""
+Laguerre
+
+basis_symbol(::Type{<:Laguerre{α}}) where {α} = "Lᵅ"
+basis_symbol(::Type{<:Laguerre{0}}) = "L"
+Polynomials.domain(::Type{<:Laguerre}) = Polynomials.Interval(0, Inf)
+
+abcde(::Type{<:Laguerre{α}})  where {α} = NamedTuple{(:a,:b,:c,:d,:e)}((0,1,0,-1,α+1))
+
+k0(P::Type{<:Laguerre}) = one(eltype(P))
+k1k0(P::Type{<:Laguerre{α}}, k::Int) where {α} = -one(eltype(P))/(k+1) # k >=0
+
+
+function norm2(::Type{<:Laguerre{α}}, n) where{α}
+    iszero(α) && return one(α)
+    Γ(n + α + 1) / Γ(n+1)
+end
+
+function ω₁₀(::Type{<:Laguerre{α}}, n) where{α}
+    iszero(α) && return 1.0
+    val = Γ(n + 1 + α + 1) / Γ(n + α + 1)
+    val /= n + 1 # Γ(n+1)/Γ(n+2)
+    sqrt(val)
+end
+
+
+weight_function(::Type{<:Laguerre{α}}) where {α} = x  -> x^α * exp(-x)
+generating_function(::Type{<:Laguerre{α}}) where {α} = (t,x) -> begin
+    exp(-t*x/(1-t))/(1-t)^(α-1)
+end
+function classical_hypergeometric(::Type{<:Laguerre{α}}, n, x) where {α}
+    α > -1 || throw(ArgumentError("α > -1 is required"))
+    as = -n
+    bs = α+1
+    Pochhammer_factorial(α+1,n)*pFq(as, bs, x)
+end
+
+gauss_nodes_weights(p::Type{P}, n) where {α, P <: Laguerre{α}} =
+    FastGaussQuadrature.gausslaguerre(n,α)
+
+
+## Overrides
+
+# default  connection between Laguerre is popping out  0s
+function Base.iterate(o::Connection{P, Q}, state=nothing) where
+    {β, P <: Laguerre{β},
+     α, Q <: Laguerre{α}}
+
+    k, n = o.k, o.n
+
+    if state == nothing
+        i = k
+        i > n && return nothing
+    elseif state + 1 > n
+        return nothing
+    else
+        i = state + 1
+    end
+
+    # α(i,k)
+    K = i - k
+    N = α - β - 1 + K
+
+    return (i, generalized_binomial(N,K)), i
+
+end
+
+
+##
+## --------------------------------------------------
+##
+@registerN MonicLaguerre AbstractCCOP1 α
+export MonicLaguerre
+ϟ(::Type{<:MonicLaguerre{α}}) where {α} = Laguerre{α}
+ϟ(::Type{<:MonicLaguerre{α,T}}) where {α,T} = Laguerre{α,T}
+@register_monic(MonicLaguerre)
+
+
+@registerN OrthonormalLaguerre AbstractCCOP1 α
+export OrthonormalLaguerre
+ϟ(::Type{<:OrthonormalLaguerre{α}}) where {α} = Laguerre{α}
+ϟ(::Type{<:OrthonormalLaguerre{α,T}}) where {α,T} = Laguerre{α,T}
+@register_orthonormal(OrthonormalLaguerre)

--- a/build/Orthogonal/Legendre.jl
+++ b/build/Orthogonal/Legendre.jl
@@ -1,0 +1,159 @@
+## Legendre Polynomials = Gegenbauer{1/2}
+
+# cf FastGaussquadrature.jl
+#include("FastLegendre.jl")
+
+
+@register0 Legendre AbstractCCOP0
+export Legendre
+
+
+"""
+    Legendre{T}
+
+Implements the [Legendre](https://en.wikipedia.org/wiki/Legendre_polynomials) polynomials. These have weight function `w(x) = 1` over the domain `[-1,1]`.
+
+```jldoctest
+julia> using Polynomials, SpecialPolynomials
+
+julia> p = Legendre([1,2,3])
+Legendre(1⋅P₀(x) + 2⋅P₁(x) + 3⋅P₂(x))
+
+julia> convert(Polynomial, p)
+Polynomials.Polynomial(-0.5 + 2.0*x + 4.5*x^2)
+
+julia> p2m, p2m1 = basis.(Legendre, (8,9)) # evaluation P_{2m+k}(-1) =  (-1)^k
+(Legendre(1.0⋅P₈(x)), Legendre(1.0⋅P₉(x)))
+
+julia> p2m(-1) == 1
+false
+
+julia> p2m1(-1) == -1
+false
+
+julia> n = 5  # verify  Rodrigues' formula 
+5
+
+julia> x = Polynomial(:x)
+Polynomials.Polynomial(1.0*x)
+
+julia> derivative((x^2-1)^n, n) - 2^n *  factorial(n) * basis(Legendre, n)
+Polynomials.Polynomial(0.0)
+
+julia> p4, p5  =  basis.(Legendre, (4,5)) # verify  orthogonality  of  P₄,P₅
+(Legendre(1.0⋅P₄(x)), Legendre(1.0⋅P₅(x)))
+
+julia> SpecialPolynomials.innerproduct(Legendre, p4,  p5)
+-1.5309832087675112e-16
+```
+"""
+Legendre
+
+abcde(::Type{<:Legendre})  = NamedTuple{(:a,:b,:c,:d,:e)}((-1,0,1,-2,0))
+
+basis_symbol(::Type{<:Legendre})  = "P"
+Polynomials.domain(::Type{<:Legendre}) = Polynomials.Interval(-1, 1)
+
+
+k0(P::Type{<:Legendre}) = one(eltype(P))
+k1k0(P::Type{<:Legendre}, n::Int) = (one(eltype(P))*(2n+1))/(n+1) #k1k0(Gegenbauer{1/2, eltype(P)}, n)
+
+norm2(::Type{<:Legendre}, n) = 2/(2n+1)
+ω₁₀(P::Type{<:Legendre}, n) = sqrt((one(eltype(P))*(2n+1))/(2n+3))
+weight_function(::Type{<:Legendre})  = x -> one(x)
+generating_function(::Type{<:Legendre}) = (t, x)  -> 1/sqrt(1 - 2x*t +t^2)
+function classical_hypergeometric(::Type{<:Legendre}, n, x)
+    as = (-n, n+1)
+    bs = (1, )
+    pFq(as, bs, (1-x)/2)
+end
+#eval_basis(::Type{P}, n, x::Float64) where {P <: Legendre} = FastLegendre.fastlegendre(n,x)
+# cf. fastgauss.jl
+# eval_basis(::Type{P}, n, x::Union{Int, Int32, Float16, Float32}) where {P <: Legendre} = FastLegendre.fastlegendre(n,float(x))
+#gauss_nodes_weights(p::Type{P}, n) where {P <: Legendre} =
+#    FastGaussQuadrature.gausslegendre(n)
+# overrides
+
+
+B̃n(P::Type{<:Legendre}, n::Int) = zero(eltype(P))
+C̃n(P::Type{<:Legendre}, n::Int) = (one(eltype(P))*n^2) / (4n^2-1)
+
+B̃n(P::Type{<:Legendre}, ::Val{0}) = B̃n(Gegenbauer{1/2, eltype(P)}, Val(0))
+C̃n(P::Type{<:Legendre}, ::Val{0}) = zero(eltype(P))
+b̂̃n(P::Type{<:Legendre}, ::Val{0}) = b̂̃n(Gegenbauer{1/2, eltype(P)}, Val(0))
+ĉ̃n(P::Type{<:Legendre}, ::Val{0}) = ĉ̃n(Gegenbauer{1/2, eltype(P)}, Val(0))
+
+function Polynomials.derivative(p::Legendre{T,X}, order::Integer = 1) where {T,X}
+    order < 0 && throw(ArgumentError("Order of derivative must be non-negative"))
+    order == 0 && return convert(Legendre{T}, p)
+    hasnan(p) && return Legendre{T,X}(T[NaN])
+    order > length(p) && return zero(Legendre{T})
+
+    d = degree(p)
+    qs = zeros(T, d)
+    for i in 0:d-1
+        gamma = 2*i+1
+        qs[i+1] = gamma * sum(p[j] for j in (i+1):2:d)
+    end
+
+    q = Legendre{T,X}(qs)
+
+    if order > 1
+        derivative(q, order-1)
+    else
+        q
+    end
+
+end
+
+##
+## --------------------------------------------------
+##
+
+# Monic
+@register0 MonicLegendre AbstractCCOP0
+export MonicLegendre
+ϟ(::Type{<:MonicLegendre}) = Legendre
+ϟ(::Type{<:MonicLegendre{T}}) where {T} = Legendre{T}
+@register_monic(MonicLegendre)
+
+## fast  gauss nodes
+pqr_symmetry(::Type{<:MonicLegendre}) = true
+pqr_weight(P::Type{<:MonicLegendre}, n, x, dπx) = (one(eltype(P)) * 2)/(1-x^2)/dπx^2
+
+##
+## --------------------------------------------------
+##
+
+@register0 ShiftedLegendre AbstractCCOP0
+"""
+    ShiftedLegendre
+
+Type for the shifted Legendre polynomials: `Pˢᵢ(x) =  Pᵢ(2x-1)` for `x ∈ [0,1]`.
+"""
+ShiftedLegendre
+
+ϟ(::Type{<:ShiftedLegendre})=Legendre
+ϟ(::Type{<:ShiftedLegendre{T}}) where {T} = Legendre{T}
+export ShiftedLegendre
+@register_shifted(ShiftedLegendre, 2, -1)
+
+B̃n(P::Type{<:ShiftedLegendre}, ::Val{0}) = -one(eltype(P))/2
+
+##
+## --------------------------------------------------
+##
+
+@register0 MonicShiftedLegendre AbstractCCOP0
+export MonicShiftedLegendre
+ϟ(::Type{<:MonicShiftedLegendre}) = ShiftedLegendre
+ϟ(::Type{<:MonicShiftedLegendre{T}}) where {T} = ShiftedLegendre{T}
+@register_monic(MonicShiftedLegendre)
+
+
+@register0 OrthonormalLegendre AbstractCCOP0
+export OrthonormalLegendre
+ϟ(::Type{<:OrthonormalLegendre}) = Legendre
+ϟ(::Type{<:OrthonormalLegendre{T}}) where {T} = Legendre{T}
+@register_orthonormal(OrthonormalLegendre)
+

--- a/build/Orthogonal/WeightFunction.jl
+++ b/build/Orthogonal/WeightFunction.jl
@@ -1,0 +1,206 @@
+## General  weight function
+## Wheeler algorithm, https://authors.library.caltech.edu/86868/1/1.4822929.pdf
+## algorithm not considered, just text
+
+abstract type AbstractWeightFunction{T,X,N} <: AbstractContinuousOrthogonalPolynomial{T,X} end
+# parent types for `@registerX` constructor
+abstract type WeightFunction{T,X,N} <: AbstractWeightFunction{T,X,N} end
+abstract type WeightFunction1{α,T,X,N} <: AbstractWeightFunction{T,X,N} end
+export WeightFunction, WeightFunction1
+
+"""
+    WeightFunction{T}
+
+A type for orthogonal polynomials relative to some weight
+function. The Wheeler or modified Chebyshev algorithm
+([Gautschi](https://www.cs.purdue.edu/homes/wxg/Madrid.pdf),
+[Press and Teukolsky](https://doi.org/10.1063/1.4822929))
+is used to generate the three-term recurrence relation. 
+
+If the second order differential equation, `σ⋅p'' + τ⋅p' + λ⋅p=-` is
+known, using that to define the polynomial type would be preferred, as
+then several additional properties follow for free.
+
+The key computation is the modified moment, `∫πⱼ dw` where `πⱼ` is the
+`j`th basis vector for an associated *monic* system, `P`, and `w` is the
+weight function.  These values are registered through the
+`@register_weight_function(Type, P, w)` macro, as
+illustrated in the examples.
+
+
+#  Example. 
+
+Toy example with `ChebyshevU` being derived using the  `Chebyshev` system.
+
+```jldoctest
+julia> using Polynomials, SpecialPolynomials
+
+julia> const SP = SpecialPolynomials
+SpecialPolynomials
+
+julia> SP.@register0 Toy SP.WeightFunction   # register a  Toy  example
+
+julia> SP.@register_weight_function Toy MonicChebyshev SP.weight_function(ChebyshevU)
+
+julia> [SP.Cn.(Toy, 1:5) SP.Cn.(MonicChebyshevU, 1:5)]
+5×2 Matrix{Float64}:
+ 0.25  0.25
+ 0.25  0.25
+ 0.25  0.25
+ 0.25  0.25
+ 0.25  0.25
+```
+
+Elliptic orthogonal polynomials on  `[-1,1]`. Demo 2 of Gautschi.
+
+```jldoctest WeightFunction
+julia> using Polynomials, SpecialPolynomials
+
+julia> const SP=SpecialPolynomials
+SpecialPolynomials
+
+julia> N,  ω² = 40, 0.999
+(40, 0.999)
+
+julia> w(t) = ((1-ω²*t^2)*(1-t^2))^(-1/2)
+w (generic function with 1 method)
+
+julia> SP.@register0 WF SP.WeightFunction
+
+julia> SP.@register_weight_function WF MonicChebyshev w
+
+julia> αs, βs = -SP.Bn.(WF, 0:5), SP.Cn.(WF, 0:5);
+
+julia> [αs βs]
+6×2 Matrix{Float64}:
+ -1.87309e-15  9.68226
+ -7.11555e-18  0.793782
+ -1.76472e-15  0.119868
+ -2.89401e-15  0.22704
+ -4.11827e-15  0.241061
+ -5.47762e-15  0.245428
+```
+
+
+The main computation involved in this is the modified moment, `νⱼ =
+∫πⱼ dw`, computed with `QuadGK.quadgk`. For some examples, this
+computation can be completed directly and the `modified_moment` method
+may be overloaded for the type. This example is from Press and
+Teukolsky, where the modified moments are given through the function
+`v(j)` defined below.
+
+```jldoctest
+julia> using Polynomials, SpecialPolynomials, SpecialFunctions
+
+julia> const SP=SpecialPolynomials
+SpecialPolynomials
+
+julia> w(t) = -log(t)
+w (generic function with 1 method)
+
+julia> SP.@register0 WF1 SP.WeightFunction   #  register  type WF1 as a weight function
+
+julia> SP.@register_weight_function WF1  MonicShiftedLegendre w
+
+julia> ν(j) = iszero(j) ? 1 : (-1)^j * gamma(j+1)^2 / (j*(j+1)*gamma(2j+1)) # help  out
+ν (generic function with 1 method)
+
+julia> SP.modified_moment(::Type{WF1},  j::Int) = ν(j)
+
+julia> αs, βs = -SP.Bn.(WF1, 0:5), SP.Cn.(WF1, 0:5);
+
+julia> [αs βs]
+6×2 Matrix{Float64}:
+ -0.75      1.0
+ -0.381148  0.423611
+ -0.504058  0.172646
+ -0.516236  0.203166
+ -0.517168  0.222419
+ -0.513854  0.239667
+```
+
+"""
+WeightFunction
+
+## We need w, π
+## w a function; π a *monic* system (ismonic(P) == true)
+weight_function(::Type{<:AbstractWeightFunction}) = throw(ArgumentError("No default method"))
+ϟ(P::Type{<:AbstractWeightFunction}) = throw(ArgumentError("No default method"))
+
+Polynomials.domain(W::Type{<:AbstractWeightFunction}) = (domain∘ϟ)(W)
+basis_symbol(::Type{<:AbstractWeightFunction}) = "W"
+
+
+
+## An,Bn,Cn for the monic orthogonal polynomials for the given weight function
+## We  have An=1;  α(n) =  -Bn(n); β(n) = Cn(n)
+An(::Type{W}, n) where {W <: AbstractWeightFunction} = one(eltype(W))
+
+function Bn(::Type{W}, k::Int) where {W <:AbstractWeightFunction}
+
+    P = ϟ(W)
+    
+    if k == 0
+        ν₀, ν₁ =  modified_moment(W, 0), modified_moment(W, 1)
+        out = Bn(P, 0) + ν₁ / ν₀
+    else
+        out = Bn(P, k) - sigma(W, k-1, k)/sigma(W, k-1, k-1)  + sigma(W, k, k+1)/sigma(W, k, k) 
+    end
+    -out
+    
+end
+
+function Cn(::Type{W}, k::Int) where  {W <: AbstractWeightFunction}
+    iszero(k) && return innerproduct(W, one, one)
+    (sigma(W, k, k)/sigma(W, k-1, k-1))
+end
+
+
+@memoize function sigma(W::Type{<:AbstractWeightFunction}, k, l) 
+
+    P = ϟ(W)
+    
+    T = eltype(W)
+    k == -1 && return zero(T)/1
+    k == 0  && return modified_moment(W, l) # ν_l = ∫π_l dw
+    k > l   && return zero(T)/1
+
+    # otherwise get through recursion (this uses Gautschi's formula, P&T have apparent error
+    sigma(W, k-1, l+1) - (Bn(W, k-1) - Bn(P, l)) * sigma(W, k-1, l) - (Cn(W, k-1))*sigma(W, k-2, l) + Cn(P,l)*sigma(W, k-1, l-1)
+    
+end
+
+## Compute the modified moment
+## v_j =  ∫ π_j ω(x) dx
+## (The moment is ∫ x^j ω(x) dx)
+## This can  be overridden when an exact calculuation is known, e.g.:
+function modified_moment(::Type{W},  j::Int) where {W <: AbstractWeightFunction}
+    P = ϟ(W)
+    @assert ismonic(P)
+    modified_moment(basis(P,j), W)
+end
+
+@memoize function modified_moment(πⱼ::AbstractOrthogonalPolynomial, W)
+    P = ϟ(W)
+    ω = weight_function(W)
+    πⱼdω = x -> πⱼ(x) * ω(x)
+    return ∫(πⱼdω, P, atol=sqrt(eps(float(eltype(W)))))
+end
+
+# integrate fdw over region specified by domain(P)
+function ∫(fdw, P; kwargs...)
+    dom = domain(P)
+    a, b = first(dom), last(dom)
+    if first(bounds_types(dom)) == Open
+        a += eps(float(one(a)))
+    end
+    if last(bounds_types(dom)) == Open    
+        b -= eps(float(one(b)))
+    end
+
+    a,err = quadgk(fdw, a, b;  kwargs...)
+    a
+end
+    
+
+

--- a/build/Orthogonal/abstract.jl
+++ b/build/Orthogonal/abstract.jl
@@ -1,0 +1,259 @@
+##
+## --------------------------------------------------
+##
+# Macros to register POLY{T,X},  POLY{αs..., T,X}
+#
+# We use `Vector{T}` with N =  d+1 to store  a degree d  polynomial - no trailing zeros permitted.
+##
+macro register0(name, parent)
+    poly = esc(name)
+    parent_type = esc(parent)
+    quote
+        struct $poly{T,X,N} <: $parent_type{T,X,N}
+            coeffs::Vector{T}
+            function $poly{T,X,N}(coeffs::Vector{T}) where {T, X, N}
+                M = length(coeffs)
+                (M  != N || (N > 0 &&iszero(coeffs[end]))) &&  throw(ArgumentError("wrong  size")) 
+                new{T,X,N}(coeffs)
+
+            end
+            function $poly{T,X,N}(coeffs::NTuple{N,T}) where {T, X, N}
+                $poly{T,X,N}(collect(coeffs))
+            end
+            function $poly{T,X}(coeffs::Vector{S}) where {T, X, S}
+                N = findlast(!iszero,coeffs)
+                N == nothing && return $poly{T,X,0}(T[])
+                new{T,X,N}(T[coeffs[i] for i ∈ firstindex(coeffs):N])
+            end
+            function $poly{T,X}(coeffs::NTuple{N,T}) where {T, X, N}
+                $poly{T,X}(collect(coeffs))
+            end
+
+            function $poly{T}(coeffs::Vector{S},  var::Polynomials.SymbolLike=:x) where {T,S}
+                N = findlast(!iszero, coeffs)
+                X = Symbol(var)
+                if N ==  nothing
+                    new{T,X,0}(T[])
+                else
+                    cs = collect(T,coeffs[1:N])
+                    new{T,X,N}(cs)
+                end
+            end
+            function $poly{T}(coeffs::NTuple{N,T}, var::Polynomials.SymbolLike=:x) where {T, N}
+                X = Symbol(var)
+                $poly{T,X}(collect(coeffs))
+            end
+            
+            function $poly(coeffs::Vector{S},  var::Polynomials.SymbolLike=:x) where {S}
+                X = Symbol(var)
+                $poly{S,X}(coeffs)
+            end
+
+        end
+
+        Base.length(p::$poly{T,X,N}) where {T,X,N} = N
+        Polynomials.evalpoly(x, p::$poly) = eval_cop(typeof(p), p.coeffs, x)
+        
+        Polynomials.@register $poly
+
+        # work around N parameter in promote(p,q) usage in defaults
+        Base.:+(p::P,q::Q) where {T,X,N,P<:$poly{T,X,N},
+                                  S,  M,Q<:$poly{S,X,M}} = ⊕(P, p, q)
+        Base.:*(p::P,q::Q) where {T,X,N,P<:$poly{T,X,N},
+                                  S,  M,Q<:$poly{S,X,M}} = ⊗(P, p, q)
+        Base.divrem(p::$poly{T}, q::$poly{T}) where {T}  = _divrem(p,q)
+    end
+end
+
+    
+
+# register macro for polynomial families with parameters
+# would be nice to consolidate, but ...
+macro registerN(name,  parent, params...)
+    poly = esc(name)
+    parent_type = esc(parent)
+    αs = tuple(esc.(params)...)
+    quote
+        struct $poly{$(αs...),T,X,N} <: $parent_type{$(αs...),T,X,N}
+            coeffs::Vector{T}
+
+            function $poly{$(αs...), T,X,N}(coeffs::Vector{T}) where {$(αs...), T,X,N}
+                M = length(coeffs)
+                (M  != N || (N > 0 &&iszero(coeffs[end]))) &&  throw(ArgumentError("wrong  size")) 
+                new{$(αs...), T,X,N}(coeffs)
+            end
+            function $poly{$(αs...),T,X,N}(coeffs::NTuple{N,T}) where {$(αs...), T,X,N}
+                $poly{$(αs...),T,X,N}(collect(T,coeffs))
+            end
+
+            function $poly{$(αs...), T,X}(coeffs::Vector{S}) where {$(αs...), T,X,S}
+                N = findlast(!iszero,coeffs)
+                N == nothing && return new{$(αs...),T,X,0}(T[])
+                new{$(αs...), T,X,N}(T[coeffs[i] for i ∈ firstindex(coeffs):N])
+            end
+            function $poly{$(αs...),T,X}(coeffs::NTuple{N,T}) where {$(αs...), T,X,N}
+                $poly{$(αs...),T,X}(collect(T,coeffs))
+            end
+
+            function $poly{$(αs...),T}(coeffs::Vector{S},  var::Polynomials.SymbolLike=:x) where {$(αs...),T,S}
+                N = findlast(!iszero, coeffs)
+                if N ==  nothing
+                    new{$(αs...),T,Symbol(var),0}(zeros(T,0))
+                else
+                    new{$(αs...),T,Symbol(var),N}(T.(coeffs[1:N]))
+                end
+            end
+            function $poly{$(αs...),T}(coeffs::NTuple{N,T},  var::Polynomials.SymbolLike=:x) where {$(αs...),T,N}
+                $poly{$(αs...),T,Symbol(var)}(collect(T,coeffs))
+            end
+
+            function $poly{$(αs...)}(coeffs::Vector{T},  var::Polynomials.SymbolLike=:x) where {$(αs...), T}
+                $poly{$(αs...),T,Symbol(var)}(coeffs)
+            end
+
+        end
+
+        Base.length(ch::$poly{$(αs...),T,X,N}) where {$(αs...),T,X,N} = N
+        Polynomials.evalpoly(x, ch::$poly) = eval_cop(typeof(ch),  ch.coeffs, x)
+        (ch::$poly)(x) = evalpoly(x, ch)
+    
+        Base.convert(::Type{P}, q::Q) where {$(αs...),T, P<:$poly{$(αs...),T}, Q <: $poly{$(αs...),T}} = q
+        Base.convert(::Type{$poly{$(αs...)}}, q::Q) where {$(αs...),T, Q <: $poly{$(αs...),T}} = q        
+        Base.promote(p1::P, p2::Q) where {$(αs...),T, P<:$poly{$(αs...),T}, Q <: $poly{$(αs...),T}} = p1,p2
+        Base.promote_rule(::Type{<:$poly{$(αs...),T}}, ::Type{<:$poly{$(αs...),S}}) where {$(αs...),T,S} =
+            $poly{$(αs...),promote_type(T, S)}
+        Base.promote_rule(::Type{<:$poly{$(αs...),T}}, ::Type{S}) where {$(αs...),T,S<:Number} = 
+            $poly{$(αs...),promote_type(T,S)}
+
+        $poly{$(αs...),T,X}(n::Number) where {$(αs...),T,X} =
+            n * one($poly{$(αs...),T,X})
+        $poly{$(αs...),T}(n::Number, var::Polynomials.SymbolLike = :x) where {$(αs...),T} =
+            n * one($poly{$(αs...),T}, var)
+        $poly{$(αs...)}(n::S, var::Polynomials.SymbolLike = :x)        where {$(αs...), S<:Number} =
+            $poly{$(αs...),S}(n,var)
+        $poly{$(αs...),T}(var::Polynomials.SymbolLike=:x)              where {$(αs...), T} =
+            variable($poly{$(αs...),T}, var)
+        $poly{$(αs...)}(var::Polynomials.SymbolLike=:x)                where {$(αs...)} =
+            variable($poly{$(αs...)}, var)
+
+        # work around N parameter in promote
+        Base.:+(p::P,q::Q) where {$(αs...),
+                                  T,X,N,P<:$poly{$(αs...),T,X,N},
+                                  S,  M,Q<:$poly{$(αs...),S,X,M}} = ⊕(P, p, q)
+        Base.:*(p::P,q::Q) where {$(αs...),
+                                  T,X,N,P<:$poly{$(αs...),T,X,N},
+                                  S,  M,Q<:$poly{$(αs...),S,X,M}} = ⊗(P, p, q)
+        Base.divrem(p1::$poly{$(αs...),T}, p2::$poly{$(αs...),T}) where {$(αs...),T}  = _divrem(p1,p2)
+
+        Polynomials._indeterminate(::Type{P}) where {$(αs...),T,X,P <: $poly{$(αs...),T,X}} = X
+    end
+end
+
+## Delegation macros
+"""
+    ϟ(P) = Q; ϟ(P{T}) where {T} =   Q{T}
+
+Used to delegate methods of P to Q.  ([slash]upkoppa[tab])
+"""
+ϟ(P::Type{<:Polynomials.AbstractPolynomial}) = throw(ArgumentError("No default for  delegation"))
+
+## Make monic version
+macro register_monic(name)
+
+    monic=esc(name)
+    
+    quote
+        SpecialPolynomials.ismonic(::Type{<:$monic}) = true
+        SpecialPolynomials.abcde(P::Type{<:$monic})  = abcde(ϟ(P))
+        SpecialPolynomials.basis_symbol(P::Type{<:$monic})  = basis_symbol(ϟ(P)) * "̃"
+        SpecialPolynomials.weight_function(P::Type{<:$monic}) = weight_function(ϟ(P))
+        Polynomials.domain(P::Type{<:$monic}) = domain(ϟ(P))
+        SpecialPolynomials.B̃n(P::Type{<:$monic}, n::Int) =  B̃n(ϟ(P),n)
+        SpecialPolynomials.B̃n(P::Type{<:$monic}, v::Val{N}) where {N} =  B̃n(ϟ(P),v)
+        SpecialPolynomials.C̃n(P::Type{<:$monic}, n::Int) =  C̃n(ϟ(P),n)
+        SpecialPolynomials.C̃n(P::Type{<:$monic}, v::Val{N}) where {N} =  C̃n(ϟ(P),v)
+        SpecialPolynomials.ẫn(P::Type{<:$monic}, v::Val{N}) where {N} =  ẫn(ϟ(P),v)
+        SpecialPolynomials.b̂̃n(P::Type{<:$monic}, v::Val{N}) where {N} =  b̂̃n(ϟ(P),v)
+        SpecialPolynomials.ĉ̃n(P::Type{<:$monic}, v::Val{N}) where {N} =  ĉ̃n(ϟ(P),v)
+    end
+end
+
+## Make ortho
+macro register_orthonormal(name)
+
+    orthonormal=esc(name)
+    
+    quote
+        SpecialPolynomials.isorthonormal(::Type{<:$orthonormal}) = true
+        SpecialPolynomials.abcde(P::Type{<:$orthonormal})  = abcde(ϟ(P))
+        SpecialPolynomials.basis_symbol(P::Type{<:$orthonormal})  = basis_symbol(ϟ(P)) * "̃"
+        SpecialPolynomials.weight_function(P::Type{<:$orthonormal}) = weight_function(ϟ(P))
+        Polynomials.domain(P::Type{<:$orthonormal}) = domain(ϟ(P))
+        SpecialPolynomials.k0(::Type{P}) where{P <: $orthonormal} = k0(ϟ(P)) / sqrt(norm2(ϟ(P),0)) 
+        SpecialPolynomials.k1k0(::Type{P},  n::Int) where{P <: $orthonormal} = k1k0(ϟ(P),n) /  ω₁₀(ϟ(P), n)
+        SpecialPolynomials.ω₁₀(P::Type{<:$orthonormal}, n::Int) = one(eltype(P))
+        
+        SpecialPolynomials.B̃n(P::Type{<:$orthonormal}, n::Int) =  B̃n(ϟ(P),n)
+        SpecialPolynomials.B̃n(P::Type{<:$orthonormal}, v::Val{N}) where {N} =  B̃n(ϟ(P),v)
+        SpecialPolynomials.C̃n(P::Type{<:$orthonormal}, n::Int) =  C̃n(ϟ(P),n)
+        SpecialPolynomials.C̃n(P::Type{<:$orthonormal}, v::Val{N}) where {N} =  C̃n(ϟ(P),v)
+        SpecialPolynomials.ẫn(P::Type{<:$orthonormal}, v::Val{N}) where {N} =  ẫn(ϟ(P),v)
+        SpecialPolynomials.b̂̃n(P::Type{<:$orthonormal}, v::Val{N}) where {N} =  b̂̃n(ϟ(P),v)
+        SpecialPolynomials.ĉ̃n(P::Type{<:$orthonormal}, v::Val{N}) where {N} =  ĉ̃n(ϟ(P),v)
+    end
+end
+
+# P̃ = P(αx+β), so P̃'' = α^2P''(α x+ β); P̃' = αP'(αx+β)
+macro register_shifted(name, alpha, beta)
+    shifted = esc(name)
+    quote
+        function SpecialPolynomials.abcde(P::Type{<:$shifted}) 
+            α,β = $alpha, $beta
+            oP = one(eltype(P))
+            a,b,c,d,e = abcde(ϟ(P))
+            ã = oP*a
+            b̃ = (oP * 2a*β)/α + (oP*b)/α
+            c̃ = (oP * (a*β^2 +b*β + c))/α^2
+            d̃ = oP *  d
+            ẽ = (oP * (d*β + e))/α
+            NamedTuple{(:a,:b,:c,:d,:e)}((ã, b̃, c̃, d̃, ẽ))
+        end
+        
+        SpecialPolynomials.basis_symbol(P::Type{<:$shifted})  = basis_symbol(ϟ(P)) * "ˢ"
+        function  Polynomials.domain(P::Type{<:$shifted})
+            α,β = $alpha, $beta
+            a, b = extrema(ϟ(P))
+            Polynomials.Interval((a- β)/α, (b - β)/α)
+        end
+        function SpecialPolynomials.k1k0(P::Type{<:$shifted}, n::Int)
+            α,β = $alpha, $beta
+            α * k1k0(ϟ(P), n)
+        end
+        
+    end
+end
+
+# Weight Functions
+macro register_weight_function(W, P, ω)
+    W′ = esc(W)
+    P′ = esc(P)
+    ω′ = esc(ω)
+    
+    quote
+        SpecialPolynomials.:ϟ(::Type{<:$W′}) =  $P′
+        SpecialPolynomials.weight_function(::Type{<:$W′}) =  $ω′
+        (ch::$W′)(x)  = clenshaw_eval(ch, x)
+    end
+end
+
+macro register_discrete_weight_function(W, xs, ws)
+    W′ = esc(W)
+    xs′ = esc(xs)
+    ws′ = esc(ws)
+    
+    quote
+        SpecialPolynomials.xs_ws(::Type{<:$W′}) = ($xs′, $ws′)
+        SpecialPolynomials.k0(::Type{<:$W′}) = 1
+        (p::$W′)(x)  = clenshaw_eval(typeof(p), coeffs(p), x)
+    end
+end

--- a/build/Orthogonal/ccop.jl
+++ b/build/Orthogonal/ccop.jl
@@ -82,7 +82,7 @@ julia> x = variable(Polynomial{𝐐})
 Polynomials.Polynomial(x)
 
 julia> [basis(MonicLegendre′{𝐐}, i)(x) for i  in 0:5]
-6-element Vector{Polynomial{T, :x} where T}:
+6-element Vector{Polynomial{T, :x} where T<:Number}:
  Polynomials.Polynomial(1//1)
  Polynomials.Polynomial(1.0*x)
  Polynomials.Polynomial(-0.3333333333333333 + 1.0*x^2)

--- a/build/Orthogonal/comrade.jl
+++ b/build/Orthogonal/comrade.jl
@@ -1,0 +1,857 @@
+## Comrade Matrix
+## The comrade matrix plays the role of the companion matrix for static basis polynomials
+
+#
+# generate the  matrix for an orhtogonal polynomial family
+# should have eigvals(comrade_matrix(p)) ≈ roots(convert(Polynomial, p))
+# This isn't exported
+function comrade_matrix(p::P) where {P <: AbstractCCOP}
+    U,V = comrade_pencil(p)
+    U * inv(V)
+end
+
+# Generate the [comrade pencil](http://www.cecm.sfu.ca/personal/pborwein/MITACS/papers/LinMatPol.pdf)
+# C₀, C₁ with λ C₁ - C₀ the linearization; and C₀ ⋅ C₁⁻¹ the companion matrix
+# can be used with square matrix coefficients
+function comrade_pencil(p::P, symmetrize=false) where {T, P <: AbstractCCOP{T}}
+    comrade_pencil(p, αβγk(p)..., symmetrize)
+end
+
+function αβγk(p::P) where {T, P <: AbstractCCOP{T}}
+    n = Polynomials.degree(p)
+    𝐏 = _comrade_pencil_type(p)
+
+    As = An.(𝐏, 0:n-1)
+    Bs = Bn.(𝐏, 0:n-1)
+    Cs = Cn.(𝐏, 1:n-1)
+    kₙ, kₙ₋₁ = leading_term(𝐏{T}, n), leading_term(𝐏{T},n-1)
+
+    # α = 1/A
+    # β = -B/A
+    # γ = C/A
+
+
+    α = inv.(As[1:end-1])
+    β = (-Bs ./ As)
+    γ = (Cs ./ As[2:end])
+
+    (α,β,γ,kₙ₋₁, kₙ)
+end
+_comrade_pencil_type(p::P) where {T, P <: AbstractCCOP{T}} =  ⟒(P){T}
+_comrade_pencil_type(p::P) where {T, M<: AbstractMatrix{T}, P <: AbstractCCOP{M}} = ⟒(P){T}
+
+# α = [α₀, α₁, ⋯, αₙ₋₂]
+# β = [β₀, β₁, ⋯, βₙ₋₂, βₙ₋₁]
+# γ = [γ₁, γ₂ ⋯, αₙ₋₁]
+# kₙ₋₁/kₙ = aₙ₋₁
+function comrade_pencil(p::P, α, β, γ, kₙ₋₁, kₙ, symmetrize=false) where {T, P <: Polynomials.AbstractPolynomial{T}}
+
+    n = degree(p)
+    R = eltype(one(T)/1)
+    C₀ = diagm(2 => zeros(R, n-2),
+               1 => γ,
+               0 => β,
+               -1 => α
+               )
+
+    C₀[end-1,end] *= kₙ * p[end]
+    C₀[end,end] *= kₙ * p[end]
+
+    for i ∈ 0:n-1
+        C₀[1+i, end] -= kₙ₋₁ * p[i]
+    end
+
+    C₁ = diagm(0 => ones(R, n))
+    C₁[end,end] = kₙ * p[end]
+
+    C₀, C₁
+end
+
+
+function comrade_pencil(p::P, α, β, γ, kₙ₋₁, kₙ, symmetrize=false) where {T, M <: AbstractMatrix{T}, P <: Polynomials.AbstractPolynomial{M}}
+
+    n = Polynomials.degree(p)
+    m,m′ = size(p[0])
+    @assert m == m′ # square
+    𝐈 = I(m)
+
+    R = eltype(one(T)/1)
+    C₀ = zeros(R, n*m, n*m)
+    C₁ = diagm(0 => ones(R, n*m))
+    Δ = 1:m
+
+    C₀[0*m .+ Δ, 0*m .+ Δ] .= β[1]
+    C₀[1*m .+ Δ, 0*m .+ Δ] .= α[1]
+
+    for i ∈ 1:n-2
+        C₀[(i-1)*m .+ Δ, i*m .+ Δ] .= γ[i] * 𝐈
+        C₀[i*m .+ Δ, i*m .+ Δ] .= β[1+i] * 𝐈
+        C₀[(i+1)*m .+ Δ, i*m .+ Δ] .= α[1+i] * 𝐈
+    end
+
+    C₀[(n-2)*m .+ Δ, (n-1)*m .+ Δ] .= γ[end] * kₙ * p[end] * 𝐈
+    C₀[(n-1)*m .+ Δ, (n-1)*m .+ Δ] .= β[end] * kₙ * p[end] * 𝐈
+
+    for i ∈ 0:n-1
+        C₀[i*m .+ Δ, (n-1)*m .+ Δ] .-= kₙ₋₁ * p[i]
+    end
+
+
+
+    C₁[(n-1)*m .+ Δ, (n-1)*m .+ Δ] .=  kₙ * p[end]
+
+    if symmetrize
+        H₀ = zeros(T, n*m, n*m)
+        for k ∈ 1:n
+            for j ∈ 1:k
+                H₀[(k-j)*m .+ Δ ,(j-1)*m .+ Δ] .= p[k]
+            end
+        end
+        return (C₀*inv(C₁)) * H₀, H₀
+    else
+        return C₀, C₁
+    end
+end
+
+"""
+    comrade_pencil_LU(p)
+
+Return an LU decomposition of `λC₁ - C₀`, where `C₀` and `C₁` are
+the pieces of the comrade pencil.
+
+The returned value is a function. We have `L,Ũ = comrade_pencil_LU(p)(λ)`.
+The upper-triangular part, `Ũ` is not quite `U`, as `U` is singluar at eigenvalues. Rather,
+this holds up to floating point
+
+```
+C₀, C₁ = comrade_pencil(p)
+L,Ũ = comrade_pencil_LU(p)(λ)
+@assert det(Ũ) ≈ 1
+Ũ[end,end] *= p(λ)
+L*Ũ - (λ*C₁ - C₀) ≈ 0 # if atol=sqrt(eps())
+```
+"""
+comrade_pencil_LU(p::P) where {P <: AbstractCCOP} =  comrade_pencil_LU(p, αβγk(p)...)
+
+function comrade_pencil_LU(p::P, α, β, γ, kₙ₋₁, kₙ) where {T, P <: Polynomials.AbstractPolynomial{T}}
+    n = degree(p)
+    R = typeof(one(T)/1)
+    # return a function of λ
+    λ -> begin
+        𝐏 = _comrade_pencil_type(p)
+        ϕs = [basis(𝐏,i)(λ) for i ∈ 0:n-1]
+        L = zeros(R, n, n)
+        U = zeros(R, n, n)
+        for i ∈ 1:n-1
+            L[i,i] = one(R)
+            L[i+1,i] = -ϕs[i]/ϕs[i+1]
+
+            U[i,i+1] = -γ[i]
+            U[i,i] = α[i] * ϕs[i+1]/ϕs[i]
+        end
+        L[end,end] = one(R)
+
+        U[1,end] = kₙ₋₁ * p[0]
+        for i ∈ 2:(n-2)
+            j = 1+i
+            U[i,end] = kₙ₋₁ * p[j-2] + ϕs[j-2]/ϕs[j-1] * U[i-1,end]
+        end
+
+        U[n-1,end] = kₙ₋₁ * p[end-2] + ϕs[end-2]/ϕs[end-1]*U[n-2,end] - kₙ*γ[end]*p[end]
+        U[end,end] = ϕs[1]/ϕs[end] / prod(α) * 1 # p(λ)
+        (L=L, U=U)
+    end
+end
+
+
+function comrade_pencil_LU(p::P, α, β, γ, kₙ₋₁, kₙ) where {T, M <: AbstractMatrix{T}, P <: Polynomials.AbstractPolynomial{M}}
+
+    m, m′ = size(p[0])
+    @assert m == m′
+    Iₘ = I(m)
+    Δ = 1:m
+
+    n = degree(p)
+    R = typeof(one(T)/1)
+
+    # return a function of λ
+    λ -> begin
+        𝐏 = _comrade_pencil_type(p)
+        ϕs = [basis(𝐏,i)(λ) for i ∈ 0:n-1]
+        L = zeros(R, n*m, n*m)
+        Ũ = zeros(R, n*m, n*m)
+        for i ∈ 1:n-1
+            i′ = i - 1
+            L[i′*m .+ Δ, i′*m .+ Δ] .= Iₘ
+            L[(i′+1)*m .+ Δ, i′*m .+ Δ] .= -ϕs[i]/ϕs[i+1] * Iₘ
+
+            Ũ[i′*m .+ Δ,(i′+1)*m .+ Δ] .= -γ[i] * Iₘ
+            Ũ[i′*m .+ Δ, i′*m .+ Δ] .= α[i] * ϕs[i+1]/ϕs[i] * Iₘ
+        end
+        END = (n-1)*m .+ Δ
+        L[END, END] .= Iₘ
+
+        Ũ[Δ, END] .= kₙ₋₁ * p[0]
+        for i ∈ 2:(n-2)
+            j = 1+i
+            i′ = i - 1
+            Ũ[i′*m .+ Δ, END] .= kₙ₋₁ * p[j-2] + ϕs[j-2]/ϕs[j-1] * Ũ[(i′-1)*m .+ Δ,END]
+        end
+
+        Ũ[(n-1-1)*m .+ Δ,END] = kₙ₋₁ * p[end-2] +
+            ϕs[end-2]/ϕs[end-1]*Ũ[(n-2-1)*m .+ Δ,END] - kₙ*γ[end]*p[end]
+
+
+        Ũ[END,END] = ϕs[1]/ϕs[end] / prod(α) * Iₘ # use Ũ, not U, which uses p(λ)
+        (L=L, U=Ũ)
+    end
+
+end
+
+
+
+## -----
+
+## Implement algorithm for eigenvalue of a comrade matrix from:
+## Fast computation of eigenvalues of companion, comrade, and related matrices
+## Jared L. Aurentz · Raf Vandebril · David S. Watkins
+
+## Overlap with AMRVW.jl, but not really, as this paper uses different transforms:
+## * a general 2x2 core transformation
+## * a GaussTransform of the type `[1 0; m 1]`
+
+abstract type AbstractTransform{T} end
+# Ci CoreTransform [c 1; 1 0]
+struct CoreTransform{T} <: AbstractTransform{T}
+    g11::T
+    g12::T
+    g21::T
+    g22::T
+end
+CoreTransform(m::Matrix) = CoreTransform(m[1,1], m[1,2], m[2,1], m[2,2])
+LinearAlgebra.norm(c::CoreTransform) = maximum(abs, splat(c))
+Base.isnan(c::CoreTransform) = isnan(c.g12) || isnan(c.g22) || isnan(c.g21) || isnan(c.g11)
+
+
+# Gi GaussTransform [1 0, m 1]
+struct GaussTransform{T} <: AbstractTransform{T}
+    m::T
+end
+
+splat(c::CoreTransform) = (c.g11, c.g12, c.g21, c.g22)
+splat(c::GaussTransform{T}) where {T}  = (one(T), zero(T), c.m, one(T))
+
+function Base.inv(c::CoreTransform)
+    b11,b12,b21,b22 = splat(c)
+    Δ = b11 * b22 - b12 * b21
+    CoreTransform(b22/Δ, -b12/Δ, -b21/Δ, b11/Δ)
+end
+
+Base.inv(g::GaussTransform) = GaussTransform(-g.m)
+
+
+# overwrite R
+# non-allocating would be better!
+function LinearAlgebra.lmul!(c::AbstractTransform, R, i)
+    ri = copy(R[i,:])
+    c11,c12,c21,c22 = splat(c)
+    R[i,:] = R[i,:] * c11 + R[i+1,:] * c12
+    R[i+1,:] = ri * c21 + R[i+1,:] * c22
+    nothing
+end
+
+## ----
+
+# Helpful for developing
+function Base.show(io::IO, c::AbstractTransform)
+    c11,c12,c21,c22 = splat(c)
+    show(IOContext(io, :compact => true), "text/plain", [c11 c12;
+                                                         c21 c22])
+    println(io)
+end
+
+
+## realize transform as a matrix
+function realize(c::AbstractTransform{T}, i, n) where {T}
+    A = diagm(0 => ones(T, n))
+    a,b,c,d = splat(c)
+    A[i,i] = a
+    A[i,i+1] = b
+    A[i+1,i] = c
+    A[i+1,i+1] = d
+    A
+end
+
+function Base.Matrix(Cs, B)
+    n = length(Cs)
+    m = size(B)[1]
+    for i ∈ n:-1:1
+        B = realize(Cs[i], i,m)*B
+    end
+    B
+end
+
+
+## ----- primary operations with CoreTransforms
+
+# type 1
+function turnover(Ci::CoreTransform,Ci1::CoreTransform,Gi::GaussTransform)
+    a11,a12,a21,a22 = splat(Ci)
+    b22,b23, b32, b33 = splat(Ci1)
+    g21 = Gi.m
+
+    â11 = a11 + a12 * (b22*g21)
+    â12 = a12
+    â21 = a21 + a22 * (b22 * g21)
+    â22 = a22
+
+    ĝ32 = b32 * g21 / â21
+
+    b̂22 = b22
+    b̂23 = b23
+    b̂32 = b32 - (ĝ32 * a22) * b22
+    b̂33 = b33 - (ĝ32 * a22) * b23
+
+    GaussTransform(ĝ32), CoreTransform(â11,â12,â21,â22), CoreTransform(b̂22,b̂23,b̂32,b̂33)
+
+end
+
+# type 2
+function turnover(Gi::GaussTransform, Gi1::GaussTransform, Ci::CoreTransform)
+    a21 = Gi.m
+    b32 = Gi1.m
+    g11,g12,g21,g22 = Ci.g11,Ci.g12,Ci.g21,Ci.g22
+
+    â11 = g11
+    â12 = g12
+    â21 = g21 + a21 * g11
+    â22 = g22 + a21 * g12
+
+    ĝ32 = b32*g21/â21
+    b̂32 = b32*g22 - ĝ32*â22
+
+    GaussTransform(ĝ32), CoreTransform(â11, â12, â21, â22), GaussTransform(b̂32)
+
+end
+
+# type 3
+function turnover(Gi::GaussTransform, Gi1::GaussTransform, G′i::GaussTransform)
+    a21 = Gi.m
+    b32 = Gi1.m
+    g21 = G′i.m
+
+    â21 = a21 + g21
+    ĝ32 = b32 * g21 / â21
+    b̂32 = b32 - ĝ32
+
+    GaussTransform(ĝ32), GaussTransform(â21), GaussTransform(b̂32)
+end
+
+function fuse(c::CoreTransform, g::GaussTransform)
+    a11,a12,a21,a22 = splat(c)
+    m = g.m
+    CoreTransform(a11 + a12 * m, a12,
+                  a21 + a22 * m, a22)
+end
+
+function fuse(g::GaussTransform, c::CoreTransform)
+    m = g.m
+    a11,a12,a21,a22 = splat(c)
+
+    CoreTransform(a11,         a12,
+                  a11*m + a21, a12*m + a22)
+end
+
+function fuse(g1::GaussTransform, g2::GaussTransform)
+    GaussTransform(g1.m + g2.m)
+end
+
+# Rlᵢ -> l′ᵢR′
+# modifies R; returns l′ᵢ
+function passthrough!(R, l, i)
+    m = l.m
+
+    m′ = -m * R[i+1,i+1]/(R[i,i] + R[i,i+1]*m)
+
+    for j ∈ 1:i+1
+        R[j,i] += m * R[j,i+1] # R[:,i]   += m * R[:,i+1]  # R * Gᵢ
+    end
+    for j ∈ i:size(R)[2]
+        R[i+1, j]  += m′ * R[i,j] # R[i+1,:] += m′ * R[i,:] # Ĝᵢ * R
+    end
+
+    R[i+1,i] = 0 # may accumulate round off
+
+    GaussTransform(-m′)
+
+end
+
+## ---- initial shift
+
+# get eigenvalues of lower 2x2 matrix of A = Cs * B
+function lower_eigs(Cs, R::Matrix{T}, n=length(Cs)) where {T}
+
+    cn11, cn12, cn21, cn22 = splat(Cs[n])
+
+    if n >= 2
+        cn1_11, cn1_12, cn1_21, cn1_22 = splat(Cs[n-1])
+
+        u11 = cn1_21 * R[n-1,n] + cn1_22 * cn11 * R[n,n]
+        u12 = cn1_21*R[n-1,n+1] + cn1_22 * cn11 * R[n,n+1] + cn1_22 * cn12 * R[n+1, n+1]
+        u21 = cn21 * R[n,n]
+        u22 = cn21 * R[n,n+1] + cn22 * R[n+1,n+1]
+
+    else
+        u11 = cn11 * R[1,1]
+        u12 = cn11 * R[1,2] + cn12 * R[2,2]
+        u21 = zero(T)
+        u22 = cn22 * R[2,2]
+    end
+
+    ρ1, ρ2 = eigen_values(u11, u12, u21, u22)
+    ρ1, ρ2
+end
+
+
+# We create bulge through Â L⁻¹ A L and chase it down through as sequence of
+# unitary operations of the type G⁻¹ Â G, G a Gauss transform
+
+L(Cs, R::Matrix{T}, random::Bool=false) where {T <: Complex} = L1(Cs, R, random)
+L(Cs, R::Matrix{T}, random::Bool=false) where {T}  = L1L2(Cs, R, random)
+
+function L1(Cs, R::Matrix{T}, random::Bool=false) where {T}
+    random && return GaussTransform(rand(T))
+
+    c11,c12,c21,c22 = splat(Cs[1])
+    r11 = R[1,1]
+    a11, a21 = c11*r11, c21*r11
+
+    ρs = lower_eigs(Cs, R)
+    ρ1 = norm(a21 - ρs[1]) < norm(a21 - ρs[2]) ? ρs[1] : ρs[2]
+
+    m = a21 / (a11 - ρ1)
+
+    (isinf(m) || isnan(m)) && return GaussTransform(rand(T))
+
+    GaussTransform(m)
+end
+
+function L1L2(Cs,R::Matrix{T}, random::Bool=false) where {T}
+    random && return (GaussTransform(rand(T)), GaussTransform(rand(T)))
+
+    ρ1, ρ2 = lower_eigs(Cs, R)
+
+    ρ1ρ2 = real(ρ1*ρ2)
+    ρ1_ρ2 = real(ρ1 + ρ2)
+
+
+    cn11,cn12,cn21,cn22 = splat(Cs[2])
+    cn1_11,cn1_12, cn1_21, cn1_22 = splat(Cs[1])
+
+    a11 = cn1_11 * R[1,1]
+    a12 = cn1_11 * R[1,2] + cn1_12 * cn11 * R[2,2]
+    a21 = cn1_21 * R[1,1]
+    a22 = cn1_21 * R[1,2] + cn1_22 * cn11 * R[2,2]
+    a32 = cn21 * R[2,2]
+
+    x1 = a11^2 +  a12 * a21 - ρ1_ρ2*a11 + ρ1ρ2
+    x2 = a21 * a11 + a22 * a21 - ρ1_ρ2*a21
+    x3 = a32 * a21
+    m1 = x2/x1
+    m2 = x3/x2
+
+    (isinf(m1) || isinf(m2) || isnan(m1) || isnan(m2)) && return (GaussTransform(rand(T)), GaussTransform(rand(T)))
+
+    # return l1, l2 (L = L2 * L1 though)
+    GaussTransform(m1), GaussTransform(m2)
+
+end
+
+
+# single-shift bulge chase
+# updates Cs, R
+function chase_bulge!(Cs, R, l1::GaussTransform)
+    n = length(Cs)
+    Cs[1] = fuse(inv(l1), Cs[1])
+    for i ∈ 1:n-1
+        l1 = passthrough!(R, l1, i)
+        l1, Cs[i], Cs[i+1] = turnover(Cs[i],Cs[i+1], l1)
+    end
+    l1 = passthrough!(R, l1, n)
+    Cs[n] = fuse(Cs[n], l1)
+    nothing
+end
+
+# double-shift bulge chase
+function chase_bulge!(Cs, R, l1l2::Tuple)
+    n = length(Cs)
+
+    l1, l2 = l1l2
+    l1′, l2′ = inv(l1), inv(l2)
+    l1′, Cs[1], l2′ = turnover(l1′, l2′, Cs[1])
+    Cs[2] = fuse(l2′, Cs[2])
+
+    for i in 1:n-2
+
+        l2 = passthrough!(R, l2, i+1)
+        l2, Cs[i+1], Cs[i+2] = turnover(Cs[i+1], Cs[i+2], l2)
+
+        l1 = passthrough!(R, l1, i)
+        l1, Cs[i], Cs[i+1] = turnover(Cs[i], Cs[i+1], l1)
+
+        l2, l1, l1′ = turnover(l1′, l2, l1)
+
+    end
+    # knit in ends
+    l2 = passthrough!(R, l2, n)
+    Cs[n] = fuse(Cs[n], l2)
+
+
+    l1 = passthrough!(R, l1, n-1)
+    l1, Cs[n-1], Cs[n] = turnover(Cs[n-1], Cs[n], l1)
+
+
+    l1 = fuse(l1′, l1)
+    l1 = passthrough!(R, l1, n)
+    Cs[n] = fuse(Cs[n], l1)
+
+    nothing
+end
+
+
+# use AVW algorithm to find eigen value of matrix
+# decomposed into Cs::Vector{GaussTransform}, B::UpperTriangular
+function AVW_eigvals(Cs, B)
+
+
+
+    max_ctr = 1
+    ctr = 0
+    while length(Cs) > 1
+
+        # get L # random if no deflation
+        if 0 < ctr < 15
+            ctr += 1
+            l = L(Cs, B)
+        else
+            l = L(Cs, B, true) # random=true
+            ctr = 1
+        end
+
+        chase_bulge!(Cs, B, l)
+        deflateQ!(Cs, B) && (ctr = 0)
+
+        # check runaway
+        max_ctr += 1
+        (!isempty(Cs) && isnan(Cs[end])) && break
+        max_ctr > 1000 && error("Failure to converge, too many steps")
+
+    end
+
+    !isempty(Cs) && lmul!(Cs[1], B, 1)
+
+    _eigvals(B)
+
+end
+
+# modifies Cs and B on deflation
+# return true if deflation
+# we deflate when off-diagonal entry < ϵ
+# paper would have |aₙ₊₁,ₙ| ≤ eps() * (|aₙ,ₙ| + |aₙ₊₁,ₙ₊₁|)
+# but we just use eps()^(2/3) which seems to work better for Float64
+function deflateQ!(Cs, B::Matrix{T}) where {T}
+    # simple case
+    # is aₙ₊₁,ₙ < eps(T)(|ann| + |an+1,n+1|)
+    n = length(Cs)
+
+    c_11, c_12, c_21, c_22 = splat(Cs[n])
+    c1_11, c1_12, c1_21, c1_22 = n > 1 ? splat(Cs[n-1]) : (zero(T), zero(T), zero(T), zero(T))
+
+
+    Rn_1n = n > 1 ? B[n-1,n] : zero(T)
+
+    an1_n = c_21 * B[n,n]
+    ann = c1_21 * Rn_1n + c1_22 * c_11 * B[n,n]
+    an1n1 = c_21 * B[n,n+1] + c_22 * B[n+1,n+1]
+
+    ϵ = cbrt(eps(real(T))^2)
+
+    #if norm(an1_n) <=  ϵ * (norm(ann) + norm(an1n1))
+    if norm(an1_n) <=  ϵ
+        n = length(Cs)
+        c = pop!(Cs)
+        lmul!(c, B, n)
+        return true
+    end
+
+    !(T <: Real) && return false
+    n == 1 && return false
+
+    c2_11, c2_12, c2_21, c2_22 = n > 2 ? splat(Cs[n-2]) : (zero(T), zero(T), zero(T), zero(T))
+    Rn_1n_1 = n > 1 ? B[n-1, n-1] : zero(T)
+    Rn_2n_1 = n > 2 ? B[n-2, n-1] : zero(T)
+    ann_1 = c1_21 * Rn_1n_1
+    an_1n_1 = c1_11 * c2_22 * Rn_1n_1 + c2_21 * Rn_2n_1
+
+    # if norm(ann_1) <=  eps(real(T)) * (norm(an_1n_1) + norm(ann))
+    if norm(ann_1) <=  ϵ
+        A = Matrix(Cs, B)
+        n = length(Cs)
+        c = pop!(Cs)
+        lmul!(c, B, n)
+        c = pop!(Cs)
+        lmul!(c, B, n-1)
+        return true
+    end
+
+    return false
+end
+
+# once algorithm is complete, this grabs eigenvalues from B
+function _eigvals(B::Matrix{T}) where {T}
+    m = size(B)[1]
+    es = Vector{complex(T)}(undef, m)
+    i = 1
+
+    #ϵ = 1000 * eps(real(T))
+    ϵ = cbrt(eps(real(T))^2)
+    while i < m
+        #if abs(B[i+1,i]) <= ϵ * (norm(B[i,i]) + norm(B[i+1,i+1]))
+        if abs(B[i+1,i]) <= ϵ
+            es[i] = B[i,i]
+            i += 1
+        else
+            r1, r2 = eigen_values(B[i,i], B[i,i+1], B[i+1,i], B[i+1,i+1])
+            es[i] = r1
+            es[i+1] = r2
+            i += 2
+        end
+    end
+
+    i == m && (es[end] = B[end,end])
+
+    LinearAlgebra.sorteig!(es)
+    es
+end
+
+# one step improves accuracy
+function newton_refinement(λs, p::P)  where {P <: AbstractCCOP}
+    p′ = derivative(p)
+    λs .- p.(λs) ./ p′.(λs)
+end
+
+
+## -----
+## from AMRVW
+# altrnative to eigvals that works with other types
+function  eigen_values(a11::T, a12::T, a21::T, a22::T) where {T <: Real}
+    b = (a11 + a22) / 2
+    c = a11 * a22 - a12 * a21
+
+    e1r, e1i, e2r, e2i = qdrtc(b,c) #qdrtc(one(b), b, c)
+    return  complex(e1r, e1i), complex(e2r, e2i)
+
+end
+
+# from `modified_quadratic.f90`
+function  eigen_values(a11::S, a12::S, a21::S, a22::S) where {S <: Complex}
+
+    tr = a11 + a22
+    detm = a11 * a22 - a21 * a12
+    disc::S = sqrt(tr * tr - 4.0 * detm)
+
+    u::S = abs(tr + disc) > abs(tr - disc) ? tr + disc : tr - disc
+    if iszero(u)
+        return zero(S), zero(S)
+    else
+        e1::S = u / 2.0
+        e2::S = detm / e1
+        return e1, e2
+    end
+
+end
+
+## Kahan quadratic equation with fma
+##  https://people.eecs.berkeley.edu/~wkahan/Qdrtcs.pdf
+
+## solve ax^2 - 2bx + c
+function qdrtc(a::T, b::T, c::T) where {T <: Real}
+    # z1, z2 roots of ax^2 - 2bx + c
+    d = discr(a,b,c)  # (b^2 - a*c), as 2 removes 4
+
+    if d <= 0
+        r = b/a  # real
+        s = sqrt(-d)/a #imag
+        return (r,s,r,-s)
+    else
+        r = sqrt(d) * (sign(b) + iszero(b)) + b
+        return (r/a, zero(T), c/r, zero(T))
+    end
+end
+
+## more work could be done here.
+function discr(a::T,b::T,c::T) where {T}
+    pie = 3.0 # depends on 53 or 64 bit...
+    d = b*b - a*c
+    e = b*b + a*c
+
+    pie*abs(d) > e && return d
+
+    p = b*b
+    dp = muladd(b,b,-p)
+    q = a*c
+    dq = muladd(a,c,-q)
+
+    (p-q) + (dp - dq)
+end
+
+function qdrtc(b::T, c::T) where {T <: Real}
+    d = b*b - c
+    if d <= 0
+        r = b  # real
+        s = sqrt(-d) #imag
+        return (r,s,r,-s)
+    else
+        r = sqrt(d) * (sign(b) + iszero(b)) + b
+        return (r, zero(T), c/r, zero(T))
+    end
+end
+
+## -----
+# In SpecialPolynomials we have P_{n+1} = (An*x + Bn) * P_n + Cn P_{n-1}
+# In paper, we have
+# αₖ pₖ = (z  - βₖ) ⋅ pₖ₋₁ - γₖ ⋅ pₖ₋₂
+## Decompose p::P into Cs, B where
+## * Cs -- a vector of Gauss Transfroms
+## * B -- an Upper triangular matrix
+## Matrix(Cs, B) is comrade matrix
+function comrade_decomposition(P::Type{<:AbstractCCOP}, ps)
+
+    n = length(ps) - 1
+    As = An.(P, 0:n-1)
+    Bs = Bn.(P, 0:n-1)
+    Cs = Cn.(P, 1:n-1)
+    kₙ, kₙ₋₁ = leading_term(P, n), leading_term(P,n-1)
+
+    p̂s = copy(ps) ./ 1
+
+    # αs = [1/A0, 1/A1, ..., 1/An-2]
+    # βs = [B0/A0, ..., Bn-1/An-1]
+    # γs = [C1/A1, ..., Cn-1/An-1]
+    # cs [ 0 ... 0 γ[end] β[end]] - ps[1:end-1]/ps[end] / An-1
+
+
+    aₙ = An(P,n)
+    βs = -Bs ./ As
+    βn = pop!(βs)
+    γs = [Cs[i]/As[i+1] for i ∈ 1:length(Cs)]
+    γn = pop!(γs)
+    pop!(As)
+    αs = 1 ./ As
+
+    p̂n = pop!(p̂s)
+    p̂s ./= p̂n
+    p̂s *= -kₙ₋₁ / kₙ
+    p̂s[end-1] += γn #* kₙ
+    p̂s[end] += βn #* kₙ
+
+    comrade_decomposition(p̂s, αs, βs, γs)
+
+end
+
+# The comrade matrix is the following (though the paper flips it for Gaussian elimination)
+# [β₁ γ₂ .  .  c₀;
+#  α₁ β₂ γ₃ .  c₁;
+#  .  α₂ β₃ γ₄ c₂;
+#  .  .  α₃ β₄ c₃;
+#  .  .  .  α₄ c₄]
+# returns Cs, B with eigvals(C1 ⋅ C2 ⋅ ⋯ ⋅ Cn * B) = roots(P(p))
+function comrade_decomposition(cs::Vector{T}, αs, βs, γs) where {T}
+
+
+    n = length(cs)
+    R = zeros(T, n, n)
+
+    CTs = Vector{CoreTransform{T}}(undef, n-1)
+
+    ĉ₀, ĉ₁ = cs[end+1-1], cs[end+1-2]
+
+    for i ∈ 1:n-2
+        λ = ĉ₀ / αs[end+1-i]
+        ĉ₀ = ĉ₁ - λ * βs[end+1-i]
+        ĉ₁ = cs[end+1 - (i+2)] - λ * γs[end+1-i]
+        CTs[i] = CoreTransform(λ, one(T), one(T), zero(T))
+    end
+    λ = ĉ₀ / αs[1]
+    CTs[end] = CoreTransform(λ, one(T), one(T), zero(T))
+    ĉ₀ = ĉ₁ - λ * βs[1]
+
+    for i ∈ 1:n-2
+        R[i, i]   = αs[end+1-i]
+        R[i, i+1] = βs[end+1-i]
+        R[i, i+2] = γs[end+1-i]
+    end
+
+    R[n-1, n-1] = αs[1]
+    R[n-1, n] = βs[1]
+    R[n,n] = ĉ₀
+
+    CTs, R
+end
+
+
+# find roots of P(p) without converting into standard basis
+# using comrade_matrix
+"""
+    roots(p::P) where {P <: AbstractCCOP}
+
+When `P` is a classical orthogonal family, finds the roots of `p` using the comrade matrix; otherwise falls back to finding the roots after conversion to the `Polynomial` type.
+
+The eigenvalue of the comrade matrix are identified using an algorithm from
+
+*Fast computation of eigenvalues of companion, comrade, and related matrices*
+by Jared L. Aurentz, Raf Vandebril, and David S. Watkins
+DOI 10.1007/s10543-013-0449-x
+BIT Numer Math (2014) 54:7–30
+
+The paper presents both a single- and double-shift version. The paper
+has this caveat: "The double-shift code was less successful. It too is
+very fast, but it is too unstable in its current form. We cannot
+recommend it for accurate computation of roots of high-degree
+polynomials. It could find use as an extremely fast method to get a
+rough estimate of the spectrum"
+
+"""
+function Polynomials.roots(p::P) where {P <: AbstractCCOP}
+    Cs, B = comrade_decomposition(P, coeffs(p))
+    λs = AVW_eigvals(Cs, B)
+
+    # hacky check on whether roots are good enough
+    ns = p.(λs) ./ derivative(p).(λs)
+    δ = maximum(abs,ns)
+    if δ  >= sqrt(eps())
+        rts = eigvals(Polynomials.companion(p))
+        if maximum(abs, p.(λs)) > maximum(abs, p.(rts))
+            return complex.(rts)
+        end
+    end
+    return newton_refinement(λs, p)
+end
+
+
+## -----
+
+## test root quality
+## could presumably be much more efficient
+## This test backwards stability
+function a_posteriori_check(λs, p::P) where {P <: AbstractCCOP}
+    ps = coeffs(p)
+    n = length(ps) - 1
+    v(λ) = [basis(P, i)(λ) for i ∈ n-1:-1:0]
+    αₙ = 1/An(P,  n - 1)
+    cₙ = ps[end-1]/ps[end] / αₙ
+    p = P(ps)
+    A = comrade_matrix(p)
+    Aₒₒ = norm(A, Inf)
+    [norm(αₙ * p(λ) / cₙ) /  (Aₒₒ * norm(v(λ), Inf)) for λ ∈ λs]
+end

--- a/build/Orthogonal/connection.jl
+++ b/build/Orthogonal/connection.jl
@@ -1,0 +1,306 @@
+## Connection and Linearization
+
+## A connection between polynomial systems `P` and `Q` is a function `C(m,n)` satisfying
+## p_n = ∑C(m,n) q_m or  pᵢ = ∑ Cʲᵢqⱼ (if unicode is helpful)
+##
+## From this a polynomial in P = ∑ aᵢ⋅pᵢ can be represented in a Q through
+##
+##  ∑ᵢ aᵢ⋅pᵢ = ∑ᵢ aᵢ  ∑ⱼ Cʲᵢqⱼ  = ∑ᵢ (∑ⱼ (aᵢ⋅Cʲᵢ)) qⱼ or ∑ⱼ (∑ᵢ aᵢCʲᵢ) qⱼ
+##
+## The choice of which depends on how the connection coefficients are presented.
+##
+## A connection between P and Q defines a `convert` method `Base.convert(Q,  p::P)`
+## Conversion can also be achieved through polynomial evaluation. For example
+## if `x=variable(Q)` then `Base.convert(Q,p) = p(x)` will also convert `p` into
+## the basis Q. This is helpful when Q is a standard basis polynomial.
+##
+## However, if Q is not a standard basis polynomial, it isn't helpful unless
+## one can multiply monomomials within Q. For standard basis polynomials this
+## is known, as  xⁱ⋅xʲ = xⁱ⁺ʲ.
+##
+## For general Q though, one needs a linearization: a function α with
+##
+##  qᵢqⱼ = ∑_k α(k,i,j) q_k
+##
+## with a given α, multiplication can be defined. The linearization can be defined
+## through composition: If P is the standard basis, connect Q to P, multiply ini P, then connect
+## to Q.
+##
+## In short, if there is a linearization then multiplication can be defined and conversion defined through
+## polynomial evaluation
+## If there is a connection defined then conversion is defined and multiplication can be defined through composition
+##
+
+
+## For `AbstractCCOP` polynomials, Koepf and Schmersau present recursive formulas for the connection coefficients
+## between Q and the standard basis, the standard and Q, and between P and Q when σ and σ̂ are the same. (This is the case when a polynomial system is parameterized, like Laguerre, Gegenbauer, Bessel, and  Jacobi.)
+
+ConvertibleTypes = Union{AbstractCOP, Polynomials.StandardBasisPolynomial,  FallingFactorial}
+kn(::Type{P},  n) where{P <: Union{Polynomials.StandardBasisPolynomial,  FallingFactorial}} = one(eltype(one(P)))
+k1k0(::Type{P},  n) where{P <: Union{Polynomials.StandardBasisPolynomial,  FallingFactorial}} = one(eltype(one(P)))
+knk_1(::Type{P},  n) where{P <: Union{Polynomials.StandardBasisPolynomial,  FallingFactorial}} = one(eltype(one(P)))
+
+
+
+## If  the connection  coefficients for  (P,Q) satisfy c₀⋅ C̃ⁱⱼ + c₁⋅C̃ⁱ⁺¹ⱼ  + c₂⋅*C̃ⁱ⁺²ⱼ = 0 for some computable
+##  values c₀,c₁,c₂ then this  will implement  `convert(Q,p::P)`
+function _convert_cop(::Type{Q}, p::P) where {P <: ConvertibleTypes,
+                                               Q <: ConvertibleTypes}
+
+    d = degree(p)
+    T,S = eltype(Q), eltype(p)  #
+    R = typeof(one(T) * p[0]/1)
+    as = zeros(R, 1+d)
+
+    λⱼⱼ = one(R)  * k0(P) / k0(Q)
+
+
+    for j in  0:d
+
+        λ = λⱼⱼ
+
+        λⱼⱼ *= k1k0(P,j) / k1k0(Q,j)
+
+        pⱼ = p[j]
+        iszero(pⱼ) && continue
+
+        C̃ʲⱼ = one(R)
+
+        as[1+j] += pⱼ * (λ * C̃ʲⱼ)
+
+        C̃ⁱ⁺²ⱼ, C̃ⁱ⁺¹ⱼ = zero(R), C̃ʲⱼ  # for recursion starting  with C̃ʲ⁺¹ⱼ, C̃ʲⱼ
+        for i in j-1:-1:0
+
+            λ *= k1k0(Q,i)
+
+            # c₀⋅ C̃ⁱⱼ + c₁⋅C̃ⁱ⁺¹ⱼ  + c₂⋅*C̃ⁱ⁺²ⱼ) = 0
+            c₀,c₁,c₂ = connection_m(P, Q, i, j)
+            C̃ⁱⱼ = iszero(c₀) ? zero(R) : -one(R)*(c₁*C̃ⁱ⁺¹ⱼ + c₂*C̃ⁱ⁺²ⱼ) / c₀
+            as[1+i] += pⱼ * (λ * C̃ⁱⱼ)
+
+            C̃ⁱ⁺²ⱼ, C̃ⁱ⁺¹ⱼ = C̃ⁱ⁺¹ⱼ, C̃ⁱⱼ
+        end
+    end
+    X = Polynomials.indeterminate(Q,p)
+    ⟒(Q){R,X}(as)
+end
+
+# ## Use FastTransform for conversion, as  possible
+# ## FastTransforms.kind2string.(0:15)
+# # Legendre<--Chebyshev
+# function _convert(::Type{Q}, p::P) where {
+#     T <: AbstractFloat,
+#     Q <: Union{Legendre, OrthonormalLegendre},
+#     P <: Union{Chebyshev{T}, OrthonormalChebyshev{T}}}
+#     ps = coeffs(p)
+#     Q(cheb2leg(ps, normcheb=isorthonormal(P), normleg=isorthonormal(Q)))
+# end
+
+# # Chebyshev<--Legendre
+# function _convert(::Type{Q}, p::P) where {
+#     T <: AbstractFloat,
+#     Q <: Union{Chebyshev, OrthonormalChebyshev},
+#     P <: Union{Legendre{T}, OrthonormalLegendre{T}}
+# }
+#     ps =  coeffs(p)
+#     Q(leg2cheb(ps, normleg=isorthonormal(P), normcheb=isorthonormal(Q)) )
+# end
+
+# # ultraspherical<--ultraspherical
+# function _convert(::Type{Q}, p::P) where {
+#     β, α,  T <: AbstractFloat,
+#     Q <: Union{Gegenbauer{β}, OrthonormalGegenbauer{β}},
+#     P <: Union{Gegenbauer{α, T}, OrthonormalGegenbauer{α, T}}
+# }
+
+#     ps =  coeffs(p)
+#     Q( ultra2ultra(ps, α, β, norm1=isorthonormal(P), norm2=isorthonormal(Q)) )
+
+# end
+
+# # Jacobi<--Jacobi
+# function _convert(::Type{Q}, p::P) where {
+#     γ, δ, α, β,  T <: AbstractFloat,
+#     Q <: Union{Jacobi{γ, δ}, OrthonormalJacobi{γ, δ}},
+#     P <: Union{Jacobi{α, β, T}, OrthonormalJacobi{α, β, T}}
+# }
+
+#     ps =  coeffs(p)
+#     Q( jac2jac(ps, α, β, γ, δ,  norm1=isorthonormal(P), norm2=isorthonormal(Q)) )
+
+# end
+
+# # Laguerre<--Laguerre
+# function _convert(::Type{Q}, p::P) where {
+#     α, β,  T <: AbstractFloat,
+#     Q <: Union{Laguerre{β}, OrthonormalLaguerre{β}},
+#     P <: Union{Laguerre{α, T}, OrthonormalLaguerre{α, T}}
+# }
+
+#     ps =  coeffs(p)
+#     Q( lag2lag(ps, α, β,  norm1=isorthonormal(P), norm2=isorthonormal(Q)) )
+
+# end
+
+
+# # Jacobi<--ultraspherical
+# function _convert(::Type{Q}, p::P) where {
+#     γ, δ, α,  T <: AbstractFloat,
+#     Q <: Union{Jacobi{γ, δ}, OrthonormalJacobi{γ, δ}},
+#     P <: Union{Gegenbauer{α, T}, OrthonormalGegenbauer{α, T}}
+# }
+
+#     ps =  coeffs(p)
+#     Q( ultra2jac(ps, α, γ, δ,  normultra=isorthonormal(P), normjac=isorthonormal(Q)) )
+
+# end
+
+# # ultraspherical<--Jacobi
+# function _convert(::Type{Q}, p::P) where {
+#     α, γ, δ,  T <: AbstractFloat,
+#     Q <: Union{Gegenbauer{α, T}, OrthonormalGegenbauer{α, T}},
+#     P <: Union{Jacobi{γ, δ}, OrthonormalJacobi{γ, δ}}
+# }
+
+#     ps =  coeffs(p)
+#     Q( jac2ultra(ps,γ, δ, α, normjac=isorthonormal(P), normultra=isorthonormal(Q)) )
+
+# end
+
+# # Jacobi<--Chebyshev
+# function _convert(::Type{Q}, p::P) where {
+#     γ, δ,  T <: AbstractFloat,
+#     Q <: Union{Jacobi{γ, δ}, OrthonormalJacobi{γ, δ}},
+#     P <: Union{Chebyshev{T}, OrthonormalChebyshev{T}}
+# }
+
+#     ps =  coeffs(p)
+#     Q( cheb2jac(ps,γ, δ, normcheb=isorthonormal(P), normjac=isorthonormal(Q)) )
+
+# end
+
+# # Chebyshev<--Jacobi
+# function _convert(::Type{Q}, p::P) where {
+#     γ, δ,  T <: AbstractFloat,
+#     Q <: Union{Chebyshev, OrthonormalChebyshev},
+#     P <: Union{Jacobi{γ, δ,T}, OrthonormalJacobi{γ, δ,T}}
+# }
+
+#     ps =  coeffs(p)
+#     Q( jac2cheb(ps,γ, δ, normjac = isorthonormal(P), normcheb=isorthonormal(Q)) )
+
+# end
+
+# # ultraspherical<--Chebyshev
+# function _convert(::Type{Q}, p::P) where {
+#     α,  T <: AbstractFloat,
+#     Q <: Union{Gegenbauer{α}, OrthonormalGegenbauer{α}},
+#     P <: Union{Chebyshev{T}, OrthonormalChebyshev{T}}
+# }
+
+#     ps =  coeffs(p)
+#     Q( cheb2ultra(ps,α, normcheb=isorthonormal(P), normultra=isorthonormal(Q)) )
+
+# end
+
+# # Chebyshev<--ultraspherical
+# function _convert(::Type{Q}, p::P) where {
+#     α,  T <: AbstractFloat,
+#     Q <: Union{Chebyshev, OrthonormalChebyshev},
+#     P <: Union{Gegenbauer{α,T}, OrthonormalGegenbauer{α,T}}
+# }
+#     ps =  coeffs(p)
+#     Q( ultra2cheb(ps,α, normultra=isorthonormal(P), normcheb=isorthonormal(Q)) )
+
+# end
+
+
+##  Koepf and Schmersa Thm 2, p11 connection for P to Q when σ = σ̂
+function connection_m(::Type{P},::Type{Q},m,n) where {
+    P <: AbstractCCOP,
+    Q <: AbstractCCOP}
+
+    a,b,c,d,e = abcde(P)
+    ā,b̄,c̄,d̄,ē = abcde(Q)
+
+    (a == ā && b == b̄ && c == c̄) || throw(ArgumentError("This connection assume σ = σ̄"))
+    a²,b²,c²,d²,d̄²,e²,ē²,m²,n² = a^2, b^2, c^2, d^2, d̄^2, e^2, ē^2, m^2, n^2
+
+    c0 = -(m-n) ⋅ (a⋅m + d - a + a⋅n) ⋅ (d̄ + 2a⋅m) ⋅ (d̄ + a + 2a⋅m) ⋅ (d̄ + 3a + 2a⋅m)
+    c0 *= (d̄ + 2a⋅m  + 2a)^2
+
+    c1 = -d⋅b⋅n⋅d̄ + 2d⋅a⋅m²⋅b + d⋅b⋅d̄ + 2d⋅a⋅m⋅b + 2d⋅ē⋅n⋅a
+    c1 += d⋅d̄⋅ē + 2d⋅d̄⋅b⋅m - m⋅b⋅d̄² - e⋅d̄² - 4a²⋅m²⋅e - m²⋅a⋅b⋅d̄ + b⋅n⋅d̄⋅a - 2e⋅d̄⋅a
+    c1 += -4a²⋅m⋅e - 4e⋅d̄⋅a⋅m + 2m²⋅a²⋅ē + 2ē⋅a²⋅n² - 2ē⋅a²⋅n - m⋅a⋅b⋅d̄ + 2m⋅d̄⋅ē⋅a
+    c1 += 2m⋅ē⋅a² - b⋅n²⋅d̄⋅a
+    c1 *= (d̄ + 2a⋅m + 2a) ⋅ (m + 1) ⋅  (d̄ + a + 2a⋅m) ⋅ (d̄ + 3a + 2a⋅m)
+
+    c2 =  -(d̄ + 2a⋅m) ⋅ (m + 1) ⋅ (-a⋅m - 2a + a⋅n - d̄ + d) ⋅ (a⋅m + a⋅n + a + d̄)
+    c2a = a⋅b²⋅m² - 4a²⋅m²⋅c - 8a²⋅m⋅c + 2a⋅m⋅b² - 4a⋅d̄⋅m⋅c + m⋅b²⋅d̄ - 4a⋅d̄⋅c - a⋅ē² + a⋅b² - c⋅d̄²
+    c2a += b⋅ē⋅d̄ - 4⋅a²⋅c + b²⋅d̄
+    c2 *= c2a ⋅ (m + 2)
+
+
+    return (c0, c1, c2)
+
+end
+
+##  Koepf and Schmersa Thm 4, p14 connection for P, Q=x^n
+function connection_m(::Type{P},::Type{Q},m,n) where {
+    P <: AbstractCCOP,
+    Q <: Polynomials.StandardBasisPolynomial}
+
+    a,b,c,d,e = abcde(P)
+
+    c0 = (m-n) ⋅ (a⋅n + d - a + a⋅m)
+
+    c1 = (m + 1) ⋅ (b⋅m + e)
+
+    c2 = c ⋅ (m + 1) ⋅ (m + 2)
+
+    return (c0, c1, c2)
+
+end
+
+##  Koepf and Schmersa Thm 5, p16 connection for P=x^n, Q
+function connection_m(::Type{P},::Type{Q},m,n) where {
+    P <: Polynomials.StandardBasisPolynomial,
+    Q <: AbstractCCOP}
+
+    ā,b̄,c̄,d̄,ē = abcde(Q)
+    ā²,b̄²,c̄²,d̄²,ē²,m²,n² = ā^2, b̄^2, c̄^2, d̄^2, ē^2, m^2, n^2
+
+    c0 =  (n - m) ⋅ (d̄ + 2ā⋅m) ⋅ (d̄ + 3ā + 2ā⋅m) ⋅ (d̄ + ā + 2ā⋅m) ⋅ (d̄ + 2ā⋅m + 2ā)^2
+
+    c1 =  (d̄⋅ē + b̄⋅d̄ +2d̄⋅b̄⋅m + 2ā⋅m²⋅b̄ + 2ā⋅m⋅b̄ +2ē⋅ā⋅n - d̄⋅b̄⋅n) ⋅ (d̄ + 2ā⋅m + 2ā)
+    c1 *= (m+1) ⋅ (d̄ + 3ā + 2ā⋅m) ⋅  (d̄ + ā + 2ā⋅m)
+
+    c2 = -(m+2)
+    c2a = -4ā²⋅c̄⋅m²
+    c2a +=  ā⋅b̄²⋅m² + 2ā⋅b̄²⋅m - 4ā⋅c̄⋅m⋅d̄ - 8ā²⋅c̄⋅m + m⋅b̄²⋅d̄ - ā⋅ē^2 - d̄²⋅c̄ + b̄⋅ē⋅d̄ -4ā²⋅c̄
+    c2a += -4ā⋅c̄⋅d̄ + ā⋅b̄² +b̄²⋅d̄
+    c2 *= c2a ⋅ (ā⋅m + ā⋅n + ā + d̄) ⋅ (m + 1) ⋅ (d̄ + 2ā⋅m)
+
+    return (c0, c1, c2)
+
+end
+
+## With an explicit connectioni
+function connection(::Type{P}, q::Q) where
+    {P <: Polynomials.AbstractPolynomial,
+     Q<:Polynomials.AbstractPolynomial}
+
+    n = degree(q)
+    T = eltype(q)
+    T = eltype(one(eltype(one(P)))*one(q)/1)
+    cs = zeros(T, n+1)
+
+    for k in 0:n
+        for (i,val) in Connection{P,Q}(n, k)
+            cs[1+k] = muladd(q[i], val, cs[1+k])
+        end
+    end
+    X = Polynomials.indeterminate(P,q)
+    ⟒(P){T,X}(cs)
+
+end

--- a/build/Orthogonal/cop.jl
+++ b/build/Orthogonal/cop.jl
@@ -1,0 +1,177 @@
+## common functionality for  COP classical orthogonal polynomials
+## These are described by 5  values: a,.b.c.d.e
+
+abstract type AbstractCOP{T,X,N} <: AbstractOrthogonalPolynomial{T,X} end
+
+function Base.promote_rule(P::Type{<:Polynomials.AbstractPolynomial{T,X}},
+                           Q::Type{<:AbstractCOP{S,X}}) where {T,S,X}
+    ϛ(Q){promote_type(T, S), X}
+end
+
+Base.promote_rule(P::Type{<:AbstractCOP{S,X}},
+                  Q::Type{<:Polynomials.AbstractPolynomial{T,X}}) where {T,S,X} =
+                      ϛ(P){promote_type(T, S), X}
+
+# generic addition for polynomials
+function ⊕(P::Type{<:AbstractCOP}, p::AbstractCOP{T,X,N} , q::AbstractCOP{S,X,M}) where {T,S,X,N,M}
+    R = promote_type(T,S)
+    P′ = ⟒(P){R,X}
+    if N > M
+        cs = Polynomials.:⊕(P, p.coeffs, q.coeffs)
+        return P′{N}(cs)
+    elseif N < M
+        cs = Polynomials.:⊕(P, q.coeffs, p.coeffs)
+        return P′{M}(cs)
+    else
+        cs = Polynomials.:⊕(P, p.coeffs, q.coeffs)
+        return P′(cs)
+    end
+end    
+
+# multiplication of polynomials of type P
+function ⊗(P::Type{<:AbstractCOP}, p::AbstractCOP{T,X,N} , q::AbstractCOP{S,X,M}) where {T,S,X,N,M}
+    isconstant(p)  && return q * constantterm(p) # scalar mult is faster, well defined
+    isconstant(q)  && return p * constantterm(q)
+    # use connection for linearization;  note:  evalauation  is  faster than _convert_cop
+    p′,q′ = _convert_cop.(Polynomial, (p,q))
+    _convert_cop(⟒(P), p′ * q′)
+#    convert(⟒(P), convert(Polynomial, p) * convert(Polynomial, q))
+
+end
+
+
+function _divrem(num::P, den::Q) where {P <: AbstractCOP, Q <: AbstractCOP}
+
+    #@assert  ⟒(P) == ⟒(Q)
+    #@assert eltype(num) == eltype(den)
+
+    p1 = convert(ϛ(P), num)
+    p2 = convert(ϛ(Q), den)
+    q,r = divrem(p1, p2)
+    convert.(⟒(P), (q,r))
+
+end
+
+##
+## -----
+##
+## interface for a  given type
+
+basis_symbol(::Type{<:AbstractCOP}) = "P"
+Polynomials.domain(::Type{<:AbstractCOP}) = Polynomials.Interval(-Inf, Inf)
+classical_hypergeometric(P::Type{<:AbstractCOP}, n, x) = throw(ArgumentError("No default method"))
+
+"""
+   abcde
+
+A named tuple returning  the  constants a,b,c,d,e  for a CCOP type with
+(a⋅x²+b⋅x+c)*P₍ᵢ₊₂₎'' + (d⋅x + e) * P₍ᵢ₊₁₎ + λᵢ Pᵢ = 0.
+"""
+abcde(::Type{<:AbstractCOP}) = throw(ArgumentError("No default method"))
+
+
+"""
+    k1k0
+
+Let  `kᵢ` be the leading  coeffiecient of the  polynomial  in  the standard basis. 
+This  function implements  `k₍ᵢ₊₁₎/kᵢ` for `i ≥ 0`.
+
+The values `kᵢ` and `k₍ᵢ₊₁₎/k₍ᵢ₋₁₎` can  be generated.
+
+The default value  leads to monic polynomials.
+"""
+k1k0(::Type{P},  i::Int) where {P<:AbstractCOP} =  one(eltype(P))
+k1k0(::Type{P},  i::Int) where {P<:Polynomials.StandardBasisPolynomial} =  one(eltype(P))
+
+"""
+      k0(::Type{P})
+
+This is  `basis(P,0)`,  most  often  just `1`, but may be different with some normalizations, such as `Orthonormal`.
+"""
+k0(::Type{P})  where{P <: AbstractCOP}  =  one(eltype(P))
+k0(::Type{P}) where {P <: Polynomials.StandardBasisPolynomial} = one(eltype(P))
+
+# Set defaults to be monic
+# For non-monic subtypes of `AbstractCOP` only need k1k0  to be defined, as `kn` and `k1k_1` come for free
+
+# kn = prod(k1k0(i) for i in 0:n-1)  *  k0(P)
+kn(::Type{P},  n::Int) where{P <: AbstractCOP} = foldr(*, (k1k0(P,i) for i in 0:n-1), init=k0(P)) 
+
+# k₍ᵢ₊₁₎/k₍ᵢ₋₁₎ =  (k₍ᵢ₊₁₎/kᵢ) ⋅ (kᵢ/k₍ᵢ₋₁₎)
+function k1k_1(::Type{P},  i::Int) where {P<:AbstractCOP}
+    @assert i > 0
+    k1k0(P,i)*k1k0(P,i-1)
+end
+
+# leading term (Section 3 table)  is kn
+leading_term(P::Type{<:AbstractCOP},  n::Int) =  kn(P, n)
+
+# square root of ratio of norm2(P,n+1)/norm2(P,n)
+# Let ωᵢ = √{∫ πᵢ² dw}, this is ωᵢ₊₁ ÷ ωᵢ
+ω₁₀(::Type{P},n)  where {P <:  AbstractCOP} = sqrt(norm2(P,n+1)/norm2(P,n))
+
+
+# Can't  change  N  here
+function Base.setindex!(p::AbstractCOP{T,X,N}, value::Number, idx::Int) where {T, X,N}
+
+    ## widen size...
+    idx < 0 &&  throw(ArgumentError("Negative index"))
+    val = T(value)
+    d = N - 1
+    if idx > d || (idx == d && iszero(value))
+        throw(ArgumentError("Polynomials of type `AbstractCOP` have a  fixed size parameter, N, which  can't  be changed through  assignment. Make new polynomial  instance?"))
+    end
+    setindex!(p.coeffs, val,  idx+1)
+end
+
+
+Polynomials.degree(p::AbstractCOP{T,X,N})  where {T,X,N} = N-1
+Polynomials.isconstant(p::AbstractCOP) = degree(p) <=  0
+
+##  Evaluation
+
+"""
+    Clenshaw evaluation of an orthogonal polynomial 
+"""
+function eval_cop(P::Type{<:AbstractCOP{T,X,N}}, cs, x::S) where {T,X,N,S}
+    N == 0 && return zero(T) * zero(S)
+    N == 1 && return (cs[1] * k0(P)) *  one(S)
+    _eval_cop(P,cs, x)
+end
+
+function _eval_cop(P::Type{<:AbstractCOP{T,X,N}}, cs, x::S) where {T,X,N,S}
+    if @generated
+        quote
+            Δ0 = cs[end - 1]
+            Δ1 = cs[end]
+            @inbounds for i in N-1:-1:2
+                Δ0, Δ1 = cs[i - 1] - Δ1 * Cn(P, i-1), Δ0 + Δ1 * muladd(x, An(P,i-1), Bn(P,i-1))
+            end
+            p₀ = k0(P)
+            p₁ =  muladd(x, An(P,0),  Bn(P,0)) * p₀
+            Δ0 * p₀  + Δ1 * p₁
+        end
+    else
+        clenshaw_eval(P, cs, x)
+    end
+end
+
+#  evaluate  basis vector through hypergeometric formulation
+(B::Basis{P})(x) where  {P <: AbstractCOP} = eval_basis(P, B.n, x)
+
+# Evaluate a basis vector without realizing it and without using Clenshaw
+eval_basis(::Type{P}, n, x) where {P <: AbstractCOP} = classical_hypergeometric(P, n, x)
+
+"""
+    eval_hyper(::P, cs,  x::S)
+
+Evaluate polynomial `P(cs)` by  computing value for each basis vector from its hypergeometric representation
+"""
+function eval_hyper(P::Type{<:AbstractCOP}, cs, x::S) where {S}
+    isempty(cs) &&  return zero(S)
+    tot = cs[1] * one(S)
+    for i in 2:length(cs)
+        tot += cs[i] * Basis(P, i-1)(x)
+    end
+    tot
+end

--- a/build/Orthogonal/glaser-liu-rokhlin.jl
+++ b/build/Orthogonal/glaser-liu-rokhlin.jl
@@ -1,0 +1,203 @@
+"""
+    glaser_liu_rokhlin_gauss_nodes(π::P, x0=pqr_start(P,degree(π));
+                                         symmetry=pqr_symmetry(P),
+                                         m=5)
+
+Find Gauss nodes and weights of the  basis  polynomial  `π = basis(P,n)`. The nodes  are the  roots of the  polynomial and the weights are computed  from known formulas.
+
+The method from  [Glaser,  Liu, and Rokhlin](DOI: 10.1137/06067016X) is  used. This is  an  O(n)  method (whereas the method  basedon the Jacobi  matrix is O(n^2)). This method fits easily  into the framework  provided  through  the `AbstractCCOP` types.  The [FastGaussQuadrature](https://github.com/JuliaApproximation/FastGaussQuadrature.jl) package provides even more efficient  algorithms and  pays attention to numerical  issues, examples of  which  can  be found in  [Hale and Townsend](https://core.ac.uk/download/pdf/9403469.pdf). The `FastGuassQuadrature` package is used when  available.
+
+
+An example:
+
+```
+function  gauss_nodes_weights(P::Type{<:Jacobi{α,β}}, n)  where {α,β}
+    # we don't  have a  good starting point  unless α=β
+    if α == β
+        xs, ws = glaser_liu_rokhlin_gauss_nodes(basis(MonicJacobi{α,β},n))
+        λ = kn(P,n)^2
+        xs, ws/λ
+    else
+        J = jacobi_matrix(P, n)
+        eig = eigen(J, extrema(P)...)
+        wts =  π̃βn(P,0) * (eig.vectors[1,:]).^2
+        eig.values,  wts
+    end
+
+end
+    
+
+pqr_start(P::Type{MonicJacobi{α,α}}, n) where {α} =  0.0 # zero(eltype(P))
+pqr_symmetry(P::Type{<:MonicJacobi{α,α}}) where {α} = true
+function pqr_weight(P::Type{<:MonicJacobi{α,α}}, n, x, dπx) where {α}
+    # https://www.chebfun.org/publications/HaleTownsend2013a.pdf
+    # Eqn  (1.4)
+    # Cnαβ should be  computed  using asymptotic formula  for larger n (§3.2.3)
+    # XXX TThere i ss ome constant  that  makes this not work....
+    β = α
+    Cnαβ = 2^(α+β+1)  
+    Cnαβ *= gamma(n + α +  1) * gamma(n + β + 1) / gamma(n + α + β + 1)
+    Cnαβ /= gamma(1 + n)
+    val = Cnαβ / (1-x^2) / dπx^2
+    val
+end
+```
+
+"""
+glaser_liu_rokhlin_gauss_nodes()
+
+"""
+    pqr
+
+Compute  `p,q,r,p',q',r'` where `p(x)y'' + q(x)y' + r(x)  = 0`. Uses
+the `a,b,c,d,e` values characterizing the  system.
+
+"""
+function pqr(P::Type{<:AbstractCCOP}, n, x)
+    a,b,c,d,e = abcde(P)
+
+    p =  a*x^2 + b*x  +  c
+    dp = 2a*x + b
+    q = d*x +  e
+    dq = d
+    r  = -(a*n*(n-1)  + d*n)
+    dr = 0
+    (p,q,r,dp,dq,dr)
+end
+
+"""
+    pqr_start(p::P, n)
+
+A starting  value for finding the gauss nodes
+"""
+pqr_start(::Type{P}, n) where {P <: AbstractCCOP} = 0
+
+"""
+    pqr_symmetry(p::P)
+
+Boolean to specify if symmetry should apply to output
+"""
+pqr_symmetry(::Type{P}) where {P <: AbstractCCOP} = false
+
+"""
+    pqr_weight(p::P, x, dx)
+
+Compute weight from x, dπx, x a node and dπx the derivative's value at the node
+"""
+pqr_weight(p::P, n, x, dx) where {P} = throw(MethodError())
+
+# We just use clenshaw to  evaluate  `p(x), dp(x)` for Newton's method below,
+# but implementing the following can be more efficient
+# ## Evaluate basis(P,n)  and its  derivative using the three-point recursion representation
+# function orthogonal_polyval_derivative(p::P, x::S) where {P <: AbstractOrthogonalPolynomial, S}
+
+#     T = eltype(p)
+#     oS = one(x)
+#     R = eltype(one(T) * oS)
+    
+#     length(p) == 0 && return (zero(R), zero(R))
+#     d = length(p) - 1
+
+#     # P0,  P_{-1} case
+#     pn,  pn_1 = P0(P,x), zero(x)
+#     dpn, dpn_1  = dP0(P,x), zero(x)
+
+#     ptot = p[0]*P0(P,x)
+#     dptot  = p[0]*dP0(P,x)
+    
+    
+#     ## we compute  forward here, finding pi, dp_i,  p_{i+1}, dp_{i+1}, ...
+#     for i in 0:d-1
+#         an, bn, cn=  An(p,i), Bn(p,i), Cn(p,i)
+#         dpn_1, dpn = dpn,  an*pn + (an*x + bn)*dpn + cn*dpn_1
+#         pn_1,  pn =  pn, (an*x + bn)*pn + cn*pn_1
+#         ptot += p[i+1]*pn
+#         dptot += p[i+1]*dpn
+#     end
+#     return (ptot, dptot)
+# end
+
+
+# run Newton's method to find zero of p
+function newton(p::P, x0::S) where  {P <: AbstractCCOP, S}
+    maxsteps = 25
+    dp  = derivative(p)
+    while maxsteps > 0
+        px, dpx = p(x0),  dp(x0) #orthogonal_polyval_derivative(p, x0)
+        Δ = px/dpx
+        isnan(Δ) && return (x0, dpx)
+        if isinf(Δ)
+            x0 += sqrt(eps())  # give a nudge from minimum or maximum
+            continue
+        end
+        x0 -= Δ
+        min(abs(Δ),abs(px)) <= sqrt(eps(S))/100 && return  x0, dp(x0)# orthogonal_polyval_derivative(p, x0)[2]
+        maxsteps -= 1
+    end
+    @warn "Newton's method did not converge from $x0"
+    NaN
+end
+
+# Second-order Runge-Kutta with global truncation error of h^2
+function RK(t0,  x0, F, h, n)
+    k0 = h*F(t0,x0)
+    local x1
+    for i in 1:n
+        t1 = t0 + h
+        k1 = h * F(t0+h,x0+k0)
+        x1 = x0 + 1/2 * (k0+k1)
+        t0, x0, k0 = t1, x1, k1
+    end
+    x1
+end
+
+function prufer(Π::Type{P},n) where {P <: AbstractCCOP}
+    (θ, x) -> begin
+        dom = domain(Π)
+        a, b = first(dom)+eps(), last(dom)-eps()
+        x = clamp(x, a, b)
+        p,q,r,dp,dq,dr = pqr(Π, n, x)
+        -inv(sqrt(r/p) + (dr*p - dp*r + 2r*q)/(2r*p) * sin(2θ)/2)
+    end
+end
+
+## Compute gauss node using  algorithm from  
+## A Fast Algorithm for the Calculation of the Roots of Special Functions
+## by Glaser, Liu, Rokhlin
+## DOI: 10.1137/06067016X
+## specialized to the orthogonal polynomial case
+function glaser_liu_rokhlin_gauss_nodes(π::P, x0=pqr_start(P,degree(π));
+                                        symmetry=pqr_symmetry(P),
+                                        m=5) where {P <: AbstractCCOP}
+
+    n = degree(π)
+    F = prufer(P, n)
+    x = float(x0)
+
+    # step 1 to get initial might be newton or might be RK
+    if symmetry && iseven(n)
+        # a max at π(x0)
+        x = RK(0, x0, F, -(pi/2)/m, m)
+    end
+    x1, dπ1 = newton(π, x)
+    rts, dπrts = [x1], [dπ1]
+    N = symmetry ? div(n+1,2) : n
+    for i in 2:N
+        xx = RK(pi/2, rts[end], F, -pi/m, m)
+        x, dπx = newton(π, xx)
+        push!(rts, x)
+        push!(dπrts, dπx)
+    end
+    if symmetry
+        if iseven(n)
+            rts = vcat(-reverse(rts), rts)
+            dπrts = vcat(-reverse(dπrts), dπrts)
+        else
+            rts = vcat(-reverse(rts[2:end]), rts)
+            dπrts = vcat(-reverse(dπrts[2:end]), dπrts)            
+        end
+    end
+    # get weights 
+    weights = pqr_weight.(P, n, rts, dπrts)
+    rts,  weights
+end

--- a/build/Orthogonal/orthogonal.jl
+++ b/build/Orthogonal/orthogonal.jl
@@ -1,0 +1,422 @@
+## Abstract  types for  orthogonal  polynomials
+
+export Basis
+
+## Has An(P), Bn(P), Cn(P)
+abstract type AbstractOrthogonalPolynomial{T,X} <: AbstractSpecialPolynomial{T,X} end
+abstract type AbstractContinuousOrthogonalPolynomial{T,X} <: AbstractOrthogonalPolynomial{T,X} end
+abstract type AbstractDiscreteOrthogonalPolynomial{T,X} <: AbstractOrthogonalPolynomial{T,X} end
+
+"""
+    AbstractOrthogonalPolynomial{T,X}
+
+Type to represent systems of orthogonal polynomials. These polynomials have  several properties, including an accompanying inner product satsifying  `⟨yᵢ, yⱼ⟩ = cᵢδᵢⱼ`.
+
+In addition to methods inherited from the underlying `AbstractPolynomial`  type, orthogonal polynomial  types may have methods   `weight_function`, `generating_function`, `leading_term`, norm2`, `jacobi_matrix`, and `gauss_nodes_weights`,  though none are  exported.
+
+
+Subtypes of `AbstractCOP <: AbstractOrthogonalPolynomial` utilize the fact that the basis  polynomials  satisfy
+
+`(ax² + bx + c)yᵢ''(x) + (dx+e)yᵢ'(x) + λᵢyᵢ(x) = 0` (or a discrete analogue)
+
+where the structural relations are functions of `a,b,c,d,e`. These allow default definitions for polynomial evaluation,   addition, multiplication, differentiation, integration, and  conversion to and from  the `Polynomial` type (the `FallingFactorial` type in the discrete  c case),
+
+A key structural relation is the three-term recursion,  `yᵢ₊₁ =  (Aᵢx +  Bᵢ)yᵢ -  Cᵢyᵢ₋₁`. For systems  specfied by  a  weight function, the  values of `Aᵢ`, `Bᵢ`, and `Cᵢ` can  be  generated, yielding formulas for polynomial evaluation, addition, and conversion to the `Polynomial`  type throughe evaluation.
+"""
+AbstractOrthogonalPolynomial
+
+
+##
+## --------------------------------------------------
+##
+function Polynomials.fromroots(P::Type{<:AbstractOrthogonalPolynomial}, roots::AbstractVector; var::Polynomials.SymbolLike = :x)
+    x = variable(P, var)
+    p =  prod(x - r for r in roots)
+end
+
+
+Base.convert(P::Type{<:AbstractOrthogonalPolynomial}, c::Number) = c * one(P)
+Base.one(P::Type{<:AbstractOrthogonalPolynomial}, var::Polynomials.SymbolLike=:x) =   basis(P,0, var) / k0(P)
+
+Polynomials.variable(P::Type{<:AbstractOrthogonalPolynomial},  var::Polynomials.SymbolLike=:x) =
+    (basis(P,1,var) / k0(P) - Bn(P,0)) / An(P,0) 
+
+## Evaluation
+
+# from type, cs, x
+function clenshaw_eval(P::Type{<:AbstractOrthogonalPolynomial{T}}, cs, x::S) where {T,S}
+    N = length(cs)
+    p₀ = k0(P)
+    R = promote_type(promote_type(T,S), typeof(An(P,0)))
+    N == 0 && return zero(R)
+    N == 1 && return (cs[1] * p₀) * one(R) 
+
+    Δ0::R = cs[end - 1]
+    Δ1::R = cs[end]
+    @inbounds for i in N-1:-1:2
+        Δ0, Δ1 = cs[i - 1] - Δ1 * Cn(P, i-1), Δ0 + Δ1 * muladd(x, An(P,i-1),Bn(P,i-1))
+    end
+    p₁ =  muladd(x, An(P,0),  Bn(P,0)) * p₀
+    return Δ0 * p₀  + Δ1 * p₁
+end
+
+
+## Connection/Linearization
+
+#  Structs for connection, linearization (connection.jl)
+struct Connection{P,Q}
+    n::Int
+    k::Int
+end
+
+struct Linearization{P,V}
+    l::Int
+    n::Int
+    m::Int
+end
+
+
+## Collect facts  about  the orthogonal polynomial system
+
+"""
+    weight_function(p)
+    weight_function(::Type{P})
+
+For an orthogonal polynomial type, a function `w` with `∫ B_n(t) B_m(t) w(t) dt = 0` when n and m are not equal.
+
+"""
+weight_function(::Type{P}) where {P <: AbstractOrthogonalPolynomial} = throw(MethodError("Not implemented"))
+weight_function(::P) where {P <: AbstractOrthogonalPolynomial} = weight_function(P)
+
+"""
+    generating_function(p)
+    generating_function(::Type{P})
+
+The generating function is a function defined by: `(t,x) -> sum(t^n Pn(x) for n in 0:oo)`.
+"""
+generating_function(::Type{P}) where {P <: AbstractOrthogonalPolynomial} = throw(MethodError("Not implemented"))
+generating_function(::P) where {P <: AbstractOrthogonalPolynomial} = generating_function(P)
+
+
+"""
+    leading_term(::Type{P},n)
+
+Return leading term of `basis(P,n)` in the  standard basis. By default this is generated through the three-point recursion.
+"""
+function leading_term(::Type{P}, n::Int) where {P <: AbstractOrthogonalPolynomial}
+    n < 0 && throw(ArgumentError("n must be a non-negative integer"))
+    n == 0 && return one(eltype(P))
+    prod(An(P,i) for i in n-1:-1:0)
+end
+
+# is P a monic polynomial system?
+ismonic(::Type{P}) where {P <: AbstractOrthogonalPolynomial} = false
+isorthonormal(::Type{P}) where {P <: AbstractOrthogonalPolynomial} = false
+
+# cf. https://en.wikipedia.org/wiki/Orthogonal_polynomials#Recurrence_relation
+# Orthogonal polynomials have a three-point recursion formula
+# parameterized here through:
+# P_{n+1} = (An*x + Bn) * P_n + Cn P_{n-1}
+# also commonly  written as
+# An⋅x⋅P_n = -P_{n+1} + Bn⋅P_n + C_n P_{n-1}
+"""
+    An(::Type{P},n)
+
+
+Orthogonal polynomials defined by a weight function satisfy a three point recursion formula of the form:
+
+`P_{n+1} = (A_n x + B_n) P_{n} - C_n P_{n-1}`
+
+If the polynomials are monic, this is usually parameterized as:
+
+`π_{n+1} = (x - α̃_n) π_n - β̃_n π_{n-1}`
+
+These functions are used through recursion when evaluating the polynomials, converting to `Polynomial` format, for constructing the Vandermonde matrix, for construction the Jacobi matrix, and elsewhere.
+"""
+An(::Type{P}, n) where {P <: AbstractOrthogonalPolynomial} = throw(ArgumentError("No default method"))
+
+"""
+    Bn(::Type{P},n)
+    Bn(p::P, n)
+
+cf. [`An()`](@ref)
+"""
+Bn(::Type{P}, n) where {P <: AbstractOrthogonalPolynomial} = throw(ArgumentError("No default method"))
+
+
+"""
+    Cn(::Type{P},n)
+    Cn(p::P, n)
+
+cf. [`An()`](@ref)
+"""
+Cn(::Type{P}, n) where {P <: AbstractOrthogonalPolynomial} = throw(ArgumentError("No default method"))
+
+
+## For monic polynomials, we have
+## π_{n+1} = (x - α̃(n)) π_{n} - β̃(n)π_{n-1}
+"""
+    π̃αn(::Type{P}, n)
+
+cf. [`An()`](@ref)
+"""
+π̃αn(P::Type{<:AbstractOrthogonalPolynomial}, n)        = - Bn(P,n) / An(P,n)
+
+"""
+    β̃n(::Type{P}, n)
+
+cf. [`An()`](@ref)
+"""
+function π̃βn(P::Type{<:AbstractOrthogonalPolynomial}, n)
+    iszero(n) &&  return innerproduct(P, one, one)
+    Cn(P,n)/An(P,n)/An(P, n-1)
+end
+
+
+"""
+    monic(p::AbstractOrthogonalPolynomial)
+
+Return `p` as a monic polynomial *when* represented in the standard basis. Retursn the zero polynomial if the degree of `p` is `-1`. 
+"""
+function monic(p::P) where {P <: AbstractOrthogonalPolynomial}
+    n = degree(p)
+    n == -1 && return ⟒(P)(0/one(eltype(p)))
+    p / (p[end]*leading_term(P, n))
+end
+
+##
+## Work with compact  basis
+##
+"""
+     Basis(P,n)
+     Basis{P}(n)
+
+The  command `basis(P,n, [var])` realizes the polynomial. `Basis(P,n)` does  not.  This  can  be  useful for  evaluation.
+"""
+struct Basis{Π}
+    n::Int
+end
+Basis(P,n) =  Basis{P}(n)
+Base.show(io::IO,  mimetype::MIME"text/plain", b::Basis{P})  where  {P} = print(io, "$(P)($(b.n))") 
+
+function  innerproduct(::P,  f::Basis{P}, g::Basis{P}) where {P}
+    n,m  = f.n, g.n
+    if n == m
+        return norm2(P, n)
+    else
+        return zero(P)
+    end
+end
+
+
+
+##
+## Vandermonde matrix can be generated through the 3-point recursion formula
+##
+function Polynomials.vander(p::Type{P}, x::AbstractVector{T}, n::Integer) where
+    {P <:  AbstractOrthogonalPolynomial,
+     T <: Number}
+    
+    A = Matrix{T}(undef, length(x), n + 1)
+
+    # for i in 0:n
+    #     A[:, i+1] = basis(P, i).(x)
+    # end
+    # return A
+    
+    A[:, 1] .= basis(P,0)(one(T)) #P0(P, one(T))
+
+    if n > 0
+        A[:, 2] .= basis(P,1).(x) #P1(P, x)
+        @inbounds for i in 1:n-1
+            # `P_{n+1} = (A_n x + B_n) P_{n} - C_n P_{n-1}`
+            n′ = i+1
+            A[:, n′+1] = (An(p,n′) * x .+ Bn(p,n′)) .* A[:, n′] .- (Cn(p,n′) * A[:, n′ - 1])
+        end
+    end
+    
+    return A
+    
+end
+
+# Jacobi matrix
+# roots(basis(P,n)) = eigvals(jacobi_matrix(P,n)), but this is more stable
+# https://en.wikipedia.org/wiki/Gaussian_quadrature#The_Golub-Welsch_algorithm
+"""
+    jacobi_matrix(::Type{P}, n)
+
+The Jacobi Matrix is a symmetric tri-diagonal matrix. The diagonal entries are the `alpha_i` values, the off diagonal entries,
+the square root of the  `beta_i` values. This matrix has the properties that
+
+* the eigenvalues are the roots of the corresponding basis vector. As these roots are important in quadrature, and finding eigenvalues of a symmetric tri-diagonal matrix yields less error than finding the eigenvalues of the companion matrix, this can be used for higher degree basis polynomials.
+* the normalized eigenvectors have initial term proportional to the weights in a quadrature formula
+
+"""
+function jacobi_matrix(::Type{P}, n) where {P <: AbstractOrthogonalPolynomial}
+    LinearAlgebra.SymTridiagonal([π̃αn(P,i) for i in 0:n-1], [sqrt(π̃βn(P,i)) for i in 1:n-1])
+end
+jacobi_matrix(p::P, n) where {P <: AbstractOrthogonalPolynomial} = jacobi_matrix(P,n)
+
+##  Compute weights and nodes for quadrature
+"""
+    gauss_nodes_weights(::Type{P}, n)
+
+Returns a tuple of nodes and weights for Gauss quadrature for the given orthogonal type.
+
+When available, the values are computed through  the `FastGaussQuadratures` package.
+
+For some types, a method from  A. Glaser, X. Liu, and V. Rokhlin. "A fast algorithm for the calculation of the roots of special functions." SIAM J. Sci. Comput., 29 (2007), 1420-1438. is used. 
+
+For others the Jacobi matrix, J_n, for which the Golub-Welsch] algorithm The nodes  are computed from the eigenvalues of J_n, the weights a scaling of the first component of the normalized eigen vectors (β_0 * [v[1] for v in vs])
+
+"""
+function gauss_nodes_weights(p::Type{P}, n) where {P <: AbstractOrthogonalPolynomial}
+    J = jacobi_matrix(P, n)
+    eig = eigen(J, extrema(P)...)
+    # Is this necessary?
+    nm  = 1 #diag(eig.vectors * eig.vectors')
+    wts =  π̃βn(P,0) * (eig.vectors[1,:] ./ nm).^2
+    eig.values,  wts
+end
+
+gauss_nodes_weights(B::Basis{P})  where  {P} = gauss_nodes_weights(B.P, B.n)
+
+    
+
+##
+## --------------------------------------------------
+##
+
+"""
+      innerproduct(::Type{P}, f, g)
+
+Compute  `<f,g> = ∫ f⋅g⋅w dx` where  `w` is the weight function of the  type  `P`  and the integral is  taken  over  the domain of the type `P`.
+"""
+function innerproduct(P::Type{<:Union{AbstractOrthogonalPolynomial}}, f, g; atol=sqrt(eps(float(eltype(P)))))
+    dom = domain(P)
+    a, b = first(dom), last(dom)
+    if first(bounds_types(dom)) == Open    
+        a += eps(float(one(a)))
+    end
+    if last(bounds_types(dom)) == Open        
+        b -= eps(float(one(b)))
+    end
+    fn = x -> f(x) * g(x) * weight_function(P)(x)
+    
+    return quadgk(fn, a, b; atol=atol)[1]
+end
+
+
+## Compute <p_i, p_i> = \| p \|^2; allows export, but work is in norm2
+Base.abs2(::Type{P}, n) where {P <: AbstractOrthogonalPolynomial} = norm2(P, n)
+
+## Compute <p_i, p_i> = \| p \|^2
+## Slow default; generally should  be directly expressed for each type
+function norm2(::Type{P}, n) where {P <: AbstractOrthogonalPolynomial}
+    p = basis(P,n)
+    innerproduct(P, p, p)
+end
+
+##
+## --------------------------------------------------
+##
+
+
+"""
+    fit([Val(S)], P::Type{<:AbstractOrthogonalPolynomial}, f, n::Int; var=:x)
+
+    Find an approximating polynomial of degree `n` or less for a function `f`, that is returns `p(x) = ∑ᵢⁿ cᵢ Pᵢ(x)` for some coefficients `cᵢ`.
+
+
+Defaults to an interpolating polynomial. To specify others, use one of `Val(:interpolating)`, `Val(:lsq)` (least squares), or `Val(:series)` (trunated series expansion) as the first argument. See [`SpecialPolynomials.cks`](@ref) for some more detail.
+
+"""
+Polynomials.fit(P::Type{<:AbstractOrthogonalPolynomial}, f, n::Int; var=:x) =
+    fit(Val(:interpolating), P, f, n, var=var)
+
+"""
+    fit(val::Val{:interpolating}, P::Type{<:AbstractOrthogonalPolynomial}, f, deg::Int; var=:x)
+
+Fit `f` with an interpolating polynomial of degree `n` orless using nodes
+`x0,x1, ..., xn`, the  zeros of `P_{n+1} = basis(P, n+1)`. and `p(xᵢ)=f(xᵢ)`.
+"""
+Polynomials.fit(val::Val{:interpolating},
+                P::Type{<:AbstractOrthogonalPolynomial}, f, n::Int;
+                var=:x) =
+                    P(cks(val, P,f,n), var)
+
+"""
+    fit(Val(:lsq), P::Type{<:AbstractOrthogonalPolynomial}, f, n::Int)
+
+Fit `f` with `p(x)=∑ d_i P_i(x)` where `p` had degree `n` or less using least squares.
+"""
+Polynomials.fit(val::Val{:lsq},
+                P::Type{<:AbstractOrthogonalPolynomial}, f, n::Int;
+                var=:x) =
+                    P(cks(val, P,f,n), var)
+
+"""
+    fit(Val(:series), P::Type{<:AbstractOrthogonalPolynomial}, f, n::Int)
+
+If `f(x)` is written as an infinite sum `∑ c_kP_k(x)`, this returns a truncated sum `∑_0^n c̃_k P_k(x)` where `n` is chosen algorithmically and `c̃_k` is chosen using an efficient manner, not necessarily through the orthogonality condition, `<f,p_k>/<p_k,p_k>`.
+
+"""
+Polynomials.fit(val::Val{:series},
+                P::Type{<:AbstractOrthogonalPolynomial}, f;
+                var=:x,kwargs...) = 
+                    P(cks(val, P,f; kwargs...), var)
+
+
+"""
+    cks(::Val{:interpolating}, ::Type{P}, f, n::Int)
+
+Fit `f` with the interpolating polynomial using roots of P_{n+1}.
+
+Let xs,ws be the gauss nodes and weights of P (xs are the zeros of P_{n+1}).
+
+Then if we interpolate `f` at the `xs` to get `p`, then
+`p(xᵢ) = f(xᵢ)` and 
+
+`∑ p_n(xᵢ) p_m(xᵢ) wᵢ = K_m δ_{nm}` and
+
+`p(x) = ∑ᵢ cᵢ Pᵢ(x)`.
+
+Using this:
+`∑ᵢ f(xᵢ)P_k(xᵢ) wᵢ =` 
+`∑ᵢ (∑_j c_j P_j(xᵢ)) P_k(xᵢ) wᵢ =`
+`∑_j c_j (K_k δ_{ik}) = c_k K_k`, So 
+`c_k = (1/K_k) ∑ᵢ f(xᵢ)P_k(xᵢ) wᵢ`
+"""
+function cks(::Val{:interpolating}, ::Type{P}, f, n::Int) where {P  <:  AbstractOrthogonalPolynomial}
+    
+    xs, ws = gauss_nodes_weights(P, n)
+    return [sum(f(xⱼ) * basis(P, k)(xⱼ) * wⱼ for (xⱼ,wⱼ) in zip(xs,ws)) / norm2(P,k) for k in 0:n]
+end
+
+
+"""
+    cks(::Val{:lsq}, ::Type{P}, f, n::Int)
+
+Fit `f` with a polynomial `∑ᵢⁿ cᵢ Pᵢ` chosen so `<f-p,f-p>_w` is as small as possible.
+ Using the normal equations, the coefficients are found to be `c_k = <f,P_k>_w / <P_k,P_k>_w.` 
+For some types an approximation to the inner product, `<f,P_k>_w` may be used.
+
+
+ref: http://www.math.niu.edu/~dattab/MATH435.2013/APPROXIMATION
+"""
+function cks(::Val{:lsq}, ::Type{P}, f, n::Int) where {P  <:  AbstractOrthogonalPolynomial}
+## return ck =  <f,P_k>/<P_k,P_k>, k =  0...n
+    [innerproduct(P, f, basis(P,k)) /norm2(P,k) for k in 0:n]
+end
+
+"""
+    cks(::Val{:series}, ::Type{P}, f, n::Int)
+
+If `f(x)` is written as an infinite sum `∑ c_kP_k(x)`, then this 
+tries to identify an `n` for which the series expansion is a good approximation and returns the coefficients. 
+
+"""
+function cks(::Val{:series}, ::Type{P}, f, n::Int) where {P  <:  AbstractOrthogonalPolynomial}
+    throw(ArgumentError("No default method"))
+end
+

--- a/build/SpecialPolynomials.jl
+++ b/build/SpecialPolynomials.jl
@@ -1,0 +1,67 @@
+module SpecialPolynomials
+
+using LinearAlgebra
+#import LinearAlgebra: dot, ⋅
+import SpecialFunctions: gamma
+
+using Polynomials
+import Polynomials: basis, isconstant, constantterm, assert_same_variable, StandardBasisPolynomial, ⟒
+export basis
+
+
+import Intervals
+import Intervals: Open, Closed, Unbounded, bounds_types
+using QuadGK
+using Memoize
+
+using HypergeometricFunctions
+
+
+
+
+include("utils.jl")
+include("abstract.jl")
+
+include("Orthogonal/abstract.jl")
+include("Orthogonal/orthogonal.jl")
+include("Orthogonal/cop.jl")
+include("Orthogonal/ccop.jl")
+
+
+include("Orthogonal/Bessel.jl")
+include("Orthogonal/Chebyshev.jl")
+include("Orthogonal/Hermite.jl")
+include("Orthogonal/Laguerre.jl")
+include("Orthogonal/Gegenbauer.jl")
+include("Orthogonal/Jacobi.jl")
+include("Orthogonal/Legendre.jl")
+include("Orthogonal/WeightFunction.jl")
+
+include("Orthogonal/Discrete/discrete-orthogonal.jl")
+include("Orthogonal/Discrete/cdop.jl")
+include("Orthogonal/Discrete/FallingFactorial.jl")
+include("Orthogonal/Discrete/Hahn.jl")
+include("Orthogonal/Discrete/Meixner.jl")
+include("Orthogonal/Discrete/Krawchouk.jl")
+include("Orthogonal/Discrete/Charlier.jl")
+include("Orthogonal/Discrete/DiscreteChebyshev.jl")
+
+include("Orthogonal/connection.jl")
+include("Orthogonal/glaser-liu-rokhlin.jl")
+include("Orthogonal/comrade.jl")
+
+
+include("Interpolating/interpolating.jl")
+include("Interpolating/Lagrange.jl")
+include("Interpolating/Newton.jl")
+
+include("Bernstein.jl")
+
+
+using Requires
+function __init__()
+    @require FastTransforms="057dd010-8810-581a-b7be-e3fc3b93f78c" include("fasttransforms.jl")
+    @require FastGaussQuadrature="442a2c76-b920-505d-bb47-c5924d526838" include("fastgaussquadrature.jl")
+end
+
+end # module

--- a/build/abstract.jl
+++ b/build/abstract.jl
@@ -1,0 +1,116 @@
+"""
+    AbstractSpecialPolynomial{T,X}
+
+An abstract type to distinguish the different polynomial types in this package.
+
+The concrete types specify different bases for the space of polynomials of degree `n` or less.
+
+This package includes:
+
+* several classic orthogonal polynomials.
+* Newton and Lagrange interpolating polynomials
+* Bernstein polynomials
+
+As many of the methods for the base `Polynomials` class are directly coded if possible, but quite a few
+depend on conversion to the base `Polynomial` type (which uses the standard polynomial basis).
+
+"""
+abstract type AbstractSpecialPolynomial{T,X} <: Polynomials.AbstractPolynomial{T,X} end
+
+# polynomial like Vector{T} with variable
+Base.eltype(::Type{<:AbstractSpecialPolynomial{T}}) where {T} = T
+Base.eltype(::Type{<:AbstractSpecialPolynomial}) = Float64
+
+# to strip off type parameters. See Polynomials.constructorof
+# We want ⟒(P{α,T,N}) = P{α} where {T, N}x
+@generated function constructorof(::Type{T}) where T
+      getfield(parentmodule(T), nameof(T))
+ end
+⟒(P::Type{<:AbstractSpecialPolynomial}) = constructorof(P)
+⟒(::Type{<:Polynomial}) = Polynomial
+
+## Display
+
+function unicode_subscript(io, j)
+    a = ("⁻","","","₀","₁","₂","₃","₄","₅","₆","₇","₈","₉")
+    for i in string(j)
+        print(io, a[Int(i)-44])
+    end
+end
+
+function Polynomials.showterm(io::IO, ::Type{P}, pj::T, var, j, first::Bool, mimetype) where {N, T, P <: AbstractSpecialPolynomial}
+    iszero(pj) && return false
+    !first &&  print(io, " ")
+    if Polynomials.hasneg(T)
+        print(io, Polynomials.isneg(pj) ? "-" :  (!first ? "+ " : ""))
+        print(io, "$(abs(pj))⋅$(basis_symbol(P))")
+    else
+        print(io, "$(pj)⋅$(basis_symbol(P))")
+    end
+
+
+    unicode_subscript(io, j)
+    print(io,"($(var))")
+    return true
+end
+
+
+# Conversion is *possible* when multiplication  in `P` is defined
+# but otherwise,  it must be handled specially
+# function Base.convert(::Type{P}, q::Q) where {P <: AbstractSpecialPolynomial, Q <: AbstractSpecialPolynomial}
+#     convert(P, convert(Polynomial, q))
+# end
+
+# return the domain as a tuple, not an interval object
+function Base.extrema(::Type{P}) where {P <: AbstractSpecialPolynomial}
+    dom = domain(P)
+    first(dom), last(dom)
+end
+Base.extrema(p::P) where {P <: AbstractSpecialPolynomial} = extrema(P)
+
+## Polynomial operations
+
+
+##
+## --------------------------------------------------
+##
+
+function Polynomials.derivative(p::P, order::Integer = 1) where {P <: AbstractSpecialPolynomial}
+    T = eltype(one(P))
+    q = convert(Polynomial{T}, p)
+    convert(⟒(P), derivative(q, order))
+end
+
+function Polynomials.integrate(p::P) where {P <: AbstractSpecialPolynomial}
+    q = convert(Polynomial, p)
+    integrate(q)
+end
+
+
+function Base.divrem(num::P, den::P) where {P <: AbstractSpecialPolynomial}
+
+    p1 = convert(Polynomial, num)
+    p2 = convert(Polynomial, den)
+    q,r = divrem(p1, p2)
+    convert.(P, (q,r))
+
+end
+
+function Polynomials.companion(p::P) where {P <: AbstractSpecialPolynomial}
+    companion(convert(Polynomial, p))
+end
+
+function Polynomials.vander(::Type{P}, x::AbstractVector{T}, n::Integer) where {P <: AbstractSpecialPolynomial, T}
+    N = length(x) - 1
+    R = typeof(one(T)/one(T))
+    V = zeros(R, N+1, n+1)
+
+    for j in 0:n
+        bj = Polynomials.basis(P, j)
+        for i in 0:N
+            V[i+1, j+1] = bj(x[i+1])
+        end
+    end
+
+    V
+end

--- a/build/fastgaussquadrature.jl
+++ b/build/fastgaussquadrature.jl
@@ -1,0 +1,15 @@
+
+gauss_nodes_weights(p::Type{P}, n) where {P <: Chebyshev} =
+    FastGaussQuadrature.gausschebyshev(n)
+
+gauss_nodes_weights(p::Type{P}, n) where {α, β, P <: Jacobi{α, β}} =
+    FastGaussQuadrature.gaussjacobi(n, α, β)
+
+include("Orthogonal/FastLegendre.jl")
+
+eval_basis(::Type{P}, n, x::Float64) where {P <: Legendre} = FastLegendre.fastlegendre(n,x)
+eval_basis(::Type{P}, n, x::Union{Int, Int32, Float16, Float32}) where {P <: Legendre} =
+    FastLegendre.fastlegendre(n,float(x))
+gauss_nodes_weights(p::Type{P}, n) where {P <: Legendre} =
+    FastGaussQuadrature.gausslegendre(n)
+

--- a/build/fasttransforms.jl
+++ b/build/fasttransforms.jl
@@ -1,0 +1,130 @@
+# code for FastTransforms.jl until that package is compatible with Polynomials v2.0.0
+
+## Use FastTransform for conversion, as  possible
+## FastTransforms.kind2string.(0:15)
+# Legendre<--Chebyshev
+function _convert(::Type{Q}, p::P) where {
+    T <: AbstractFloat,
+    Q <: Union{Legendre, OrthonormalLegendre},
+    P <: Union{Chebyshev{T}, OrthonormalChebyshev{T}}}
+    ps = coeffs(p)
+    Q(cheb2leg(ps, normcheb=isorthonormal(P), normleg=isorthonormal(Q)))
+end
+
+# Chebyshev<--Legendre
+function _convert(::Type{Q}, p::P) where {
+    T <: AbstractFloat,
+    Q <: Union{Chebyshev, OrthonormalChebyshev},
+    P <: Union{Legendre{T}, OrthonormalLegendre{T}}
+}
+    ps =  coeffs(p)
+    Q(leg2cheb(ps, normleg=isorthonormal(P), normcheb=isorthonormal(Q)) )
+end
+
+# ultraspherical<--ultraspherical
+function _convert(::Type{Q}, p::P) where {
+    β, α,  T <: AbstractFloat,
+    Q <: Union{Gegenbauer{β}, OrthonormalGegenbauer{β}},
+    P <: Union{Gegenbauer{α, T}, OrthonormalGegenbauer{α, T}}
+}
+    
+    ps =  coeffs(p)
+    Q( ultra2ultra(ps, α, β, norm1=isorthonormal(P), norm2=isorthonormal(Q)) )
+       
+end
+       
+# Jacobi<--Jacobi
+function _convert(::Type{Q}, p::P) where {
+    γ, δ, α, β,  T <: AbstractFloat,
+    Q <: Union{Jacobi{γ, δ}, OrthonormalJacobi{γ, δ}},
+    P <: Union{Jacobi{α, β, T}, OrthonormalJacobi{α, β, T}}
+}
+    
+    ps =  coeffs(p)
+    Q( jac2jac(ps, α, β, γ, δ,  norm1=isorthonormal(P), norm2=isorthonormal(Q)) )
+    
+end
+
+# Laguerre<--Laguerre
+function _convert(::Type{Q}, p::P) where {
+    α, β,  T <: AbstractFloat,
+    Q <: Union{Laguerre{β}, OrthonormalLaguerre{β}},
+    P <: Union{Laguerre{α, T}, OrthonormalLaguerre{α, T}}
+}
+
+    ps =  coeffs(p)
+    Q( lag2lag(ps, α, β,  norm1=isorthonormal(P), norm2=isorthonormal(Q)) )
+    
+end
+
+
+# Jacobi<--ultraspherical
+function _convert(::Type{Q}, p::P) where {
+    γ, δ, α,  T <: AbstractFloat,
+    Q <: Union{Jacobi{γ, δ}, OrthonormalJacobi{γ, δ}},
+    P <: Union{Gegenbauer{α, T}, OrthonormalGegenbauer{α, T}}
+}
+    
+    ps =  coeffs(p)
+    Q( ultra2jac(ps, α, γ, δ,  normultra=isorthonormal(P), normjac=isorthonormal(Q)) )
+    
+end
+
+# ultraspherical<--Jacobi
+function _convert(::Type{Q}, p::P) where {
+    α, γ, δ,  T <: AbstractFloat,
+    Q <: Union{Gegenbauer{α, T}, OrthonormalGegenbauer{α, T}},
+    P <: Union{Jacobi{γ, δ}, OrthonormalJacobi{γ, δ}}
+}
+    
+    ps =  coeffs(p)
+    Q( jac2ultra(ps,γ, δ, α, normjac=isorthonormal(P), normultra=isorthonormal(Q)) )
+    
+end
+
+# Jacobi<--Chebyshev
+function _convert(::Type{Q}, p::P) where {
+    γ, δ,  T <: AbstractFloat,
+    Q <: Union{Jacobi{γ, δ}, OrthonormalJacobi{γ, δ}},
+    P <: Union{Chebyshev{T}, OrthonormalChebyshev{T}}
+}
+    
+    ps =  coeffs(p)
+    Q( cheb2jac(ps,γ, δ, normcheb=isorthonormal(P), normjac=isorthonormal(Q)) )
+    
+end
+
+# Chebyshev<--Jacobi
+function _convert(::Type{Q}, p::P) where {
+    γ, δ,  T <: AbstractFloat,
+    Q <: Union{Chebyshev, OrthonormalChebyshev},
+    P <: Union{Jacobi{γ, δ,T}, OrthonormalJacobi{γ, δ,T}}
+}
+    
+    ps =  coeffs(p)
+    Q( jac2cheb(ps,γ, δ, normjac = isorthonormal(P), normcheb=isorthonormal(Q)) )
+    
+end
+
+# ultraspherical<--Chebyshev
+function _convert(::Type{Q}, p::P) where {
+    α,  T <: AbstractFloat,
+    Q <: Union{Gegenbauer{α}, OrthonormalGegenbauer{α}},
+    P <: Union{Chebyshev{T}, OrthonormalChebyshev{T}}
+}
+
+    ps =  coeffs(p)
+    Q( cheb2ultra(ps,α, normcheb=isorthonormal(P), normultra=isorthonormal(Q)) )
+    
+end
+
+# Chebyshev<--ultraspherical
+function _convert(::Type{Q}, p::P) where {
+    α,  T <: AbstractFloat,
+    Q <: Union{Chebyshev, OrthonormalChebyshev},
+    P <: Union{Gegenbauer{α,T}, OrthonormalGegenbauer{α,T}}
+}
+    ps =  coeffs(p)
+    Q( ultra2cheb(ps,α, normultra=isorthonormal(P), normcheb=isorthonormal(Q)) )
+    
+end

--- a/build/utils.jl
+++ b/build/utils.jl
@@ -1,0 +1,150 @@
+# some utility functions
+const Γ = gamma
+
+
+function generalized_binomial(α::T, n::S) where {T,S <: Integer}
+    R = Base.promote_op(/,T,S)
+    out = one(R)
+    for i in n:-1:1
+        out *= α/i
+        α -= 1
+    end
+    out
+end
+
+## memoized version of the above
+@memoize function generalized_binomial′(a, k::Int)
+    k < 0 && return NaN * one(a)
+    k == 0 && return one(a)/1
+    generalized_binomial′(a,k-1) * (a-k+1)/k
+end
+
+
+
+## x⁽ⁱ⁾ is falling (x)⋅(x-1)⋯(x-n+1)
+function Pochhammer(::Val{:falling}, z::T,n::Int) where {T}
+    iszero(n) && return one(T)    
+    out = z
+    for i in 1:n-1
+        z -= 1
+        out *= z
+    end
+    out
+end
+
+## (x)ᵢ is rising (x)⋅(x+1)⋯(x+n-1) = Γ(z+n)/Γ(z)
+function Pochhammer(::Val{:rising}, z::T,n::Int) where {T}
+    iszero(n) && return one(T)
+    out = z
+    for i in 1:n-1
+        z += 1
+        out *= z
+    end
+    out
+end
+# default is (x)ᵢ
+Pochhammer(z,n::Int) = Pochhammer(Val(:rising),  z, n)
+
+
+# (x)_n/n!
+Pochhammer_factorial(z, n) = Pochhammer_factorial(Val(:rising), z, n)
+
+function Pochhammer_factorial(::Val{:rising}, z, n)
+    iszero(n) && return one(z)/1
+    prod((z+i)/(n-i) for i in 0:n-1)
+end
+
+## Alternative to HypergeometricFunctions.jl so that
+## variables can be inserted into the numerator
+"""
+    pFq(as, bs, z; [maxevals=1000])
+
+Compute the generalized [hypergeometric](https://en.wikipedia.org/wiki/Generalized_hypergeometric_function) function. The `HypergeometricFunction.jl` package would normally be used for such calculations, but this one accepts polynomial values for the `as` and `z` values.
+
+# Example
+
+From [mathworld](https://mathworld.wolfram.com/HypergeometricFunction.html)
+
+```jldoctest
+julia> using Polynomials, SpecialPolynomials
+
+julia> import SpecialPolynomials: pFq, Pochhammer
+
+julia> pFq((1/3,2/3), 5/6, 27/32) ≈ 8/5
+true
+
+julia> pFq([1/4, 1/2], [3/4], 80/81; maxevals=2000) ≈ 9/5
+true
+
+julia> x = variable()
+Polynomials.Polynomial(x)
+
+julia> n = 5
+5
+
+julia> pFq((-n,n+1), 1, (1-x)/2) ≈ basis(Legendre,n)(x)
+true
+
+julia> α, β, n = 1/2, 1/2, 5;
+
+julia> Pochhammer(α+1,n)/factorial(n) * pFq((-n,n+α+β+1), α+1, (1-x)/2) ≈ basis(Jacobi{α,β}, n)(x)
+true
+```
+"""
+function pFq(as, bs, z; maxevals=1000)
+    n = 1
+    acc = trm = one(z)
+
+    p,q = length(as), length(bs)
+
+    # element in `as` is negative integer or 0 && converges
+    # p ≤ q && converges
+    # p = q + 1 |x| < 1 && converge
+    # p > q + 1 && diverges
+    while n < maxevals
+        a = isempty(as) ? 1 : prod(as)
+        b = isempty(bs) ? 1 : prod(bs)
+
+        iszero(a) && return acc
+        iszero(b) && return Inf  # check on b
+
+        trm *= a /b * z  /n
+        acc += trm
+
+        as = plus_1(as)
+
+        bs = plus_1(bs)
+        n += 1
+    end
+
+    if (p > q + 1 || (p == q+1 && abs(z) < 1))
+        return acc
+    else
+        NaN*acc
+    end
+end
+## tuples
+@inline plus_1(as) = map(x->x+1, as)
+        
+
+# use HypergeometricFunction.mFn if possible
+function pFq(as::Tuple{A,B}, bs::Tuple{C}, z::AbstractFloat) where {A,B,C}
+    HypergeometricFunctions._₂F₁(as[1],as[2],bs[1],z)
+end
+function pFq(as::Tuple{A,B,C}, bs::Tuple{D,E}, z::AbstractFloat) where {A,B,C,D,E}
+    HypergeometricFunctions._₃F₂(as[1],as[2],as[3],bs[1],bs[2],z)
+end
+    
+
+
+## Try to speed up  quadgk by not specializing on F
+mutable struct Wrapper
+    F
+end
+(F::Wrapper)(x) = F.F(x)
+
+_quadgk(f, a, b) = quadgk(Wrapper(f), a, b)[1]
+const ∫ = _quadgk
+
+
+checked_div(a, b) = (iszero(a) && iszero(b)) ? a : a/b

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -132,7 +132,7 @@ julia> p4,p5 = basis.(P, [4,5])
 2-element Vector{Legendre{Float64, :x, N} where N}:
  Legendre(1.0⋅P₄(x))
  Legendre(1.0⋅P₅(x))
- 
+
 julia> wf, dom = SpecialPolynomials.weight_function(P), domain(P);
 
 julia> quadgk(x -> p4(x) * p5(x) *  wf(x), first(dom), last(dom))
@@ -150,7 +150,7 @@ julia> SpecialPolynomials.innerproduct(P, p4, p5)
 
 ## Polynomial methods
 
-For each polynomial type, this package implements as many of the methods for polynomials defined in `Polynomials`, as possible. 
+For each polynomial type, this package implements as many of the methods for polynomials defined in `Polynomials`, as possible.
 
 ### Evaluation
 
@@ -283,7 +283,7 @@ The first uses a method from the `FastTransforms` package. This package can hand
 
 ### Roots
 
-The `roots` function finds the roots of a polynomial 
+The `roots` function finds the roots of a polynomial
 
 ```jldoctest example
 julia> p = Legendre([1,2,2,1])
@@ -301,10 +301,10 @@ julia> p.(rts)
   0.0
   0.0
 ```
- 
- 
+
+
 Here we see `fromroots` and `roots` are related, provided a monic polynomial is used:
- 
+
 ```jldoctest example
 julia> using Polynomials, SpecialPolynomials; const SP=SpecialPolynomials
 SpecialPolynomials
@@ -319,16 +319,14 @@ typename(Jacobi){0.5,-0.5}(1⋅Jᵅᵝ₀(x) + 1⋅Jᵅᵝ₁(x) + 2⋅Jᵅᵝ�
 julia> q = SP.monic(p) # monic is not exported
 typename(Jacobi){0.5,-0.5}(0.13333333333333333⋅Jᵅᵝ₀(x) + 0.13333333333333333⋅Jᵅᵝ₁(x) + 0.26666666666666666⋅Jᵅᵝ₂(x) + 0.4⋅Jᵅᵝ₃(x))
 
-julia> fromroots(P, roots(q)) - q |> u -> truncate(u, atol=sqrt(eps())) 
+julia> fromroots(P, roots(q)) - q |> u -> truncate(u, atol=sqrt(eps()))
 typename(Jacobi){0.5,-0.5}(0.0)
 ```
- 
-The roots are found from the eigenvalues of the companion matrix,
-which may be directly produced  by `companion`; the default is  to find  it after
-conversion to the standard basis.
- 
-For orthogonal polynomials, the roots of the basis vectors are important for quadrature. For larger values of `n`, the eigenvalues of the unexported `jacobi_matrix` also identify these roots, but the algorithm is more stable.
- 
+
+For many of the orthogonal polynomials, the roots are found from the *comrade matrix* using a ``\mathcal{O}(n^2)`` algorithm of Aurentz, Vandebril, and Watkins, which computes in a more efficient manner the `eigvals(SpecialPolynomials.comrade_matrix(p))`. Alternatively, in theory roots may be identified from the companion matrix of the polynomial, once expressed in the standard basis. This approach is the fallback approach for other polynomial types, but is prone to numeric issues.
+
+For orthogonal polynomials, the roots of the basis vectors are important for quadrature. For larger values of `n`, the eigenvalues of the unexported `jacobi_matrix` also identify these roots, but the algorithm is more stable than conversion to the standard basis
+
 ```jldoctest example
 julia> using LinearAlgebra
 
@@ -355,10 +353,18 @@ julia> eigvals(SpecialPolynomials.jacobi_matrix(Legendre, 5))
 At higher degrees, the difference in  stability comes out:
 
 ```jldoctest example
-julia> p50 = basis(Legendre{Float64}, 50); sum(isreal.(roots(p50)))
+julia> using LinearAlgebra
+
+julia> p50 = basis(Legendre{Float64}, 50)
+Legendre(1.0⋅P₅₀(x))
+
+julia> sum(isreal, eigvals(Polynomials.companion(p50)))
 34
 
-julia> eigvals(SpecialPolynomials.jacobi_matrix(Legendre, 50 ))  .|> isreal |> sum
+julia> sum(isreal, roots(p50))
+50
+
+julia> sum(isreal, eigvals(SpecialPolynomials.jacobi_matrix(Legendre, 50 )))
 50
 ```
 
@@ -442,7 +448,7 @@ polynomial to the function generating the `y` values.
 
 For an orthogonal polynomial type, the zeros of the basis
 polynomial `p_{n+1}`, labeled `x_0, x_1, ..., x_n` are often used as
-nodes, especially for the Chebyshev nodes (of the first kind).  
+nodes, especially for the Chebyshev nodes (of the first kind).
 [Gil, Segura, and Temme](https://archive.siam.org/books/ot99/OT99SampleChapter.pdf) say
 "Interpolation with Chebyshev nodes is not as good as the best
 approximation ..., but usually it is the best practical possibility

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -289,17 +289,11 @@ The `roots` function finds the roots of a polynomial
 julia> p = Legendre([1,2,2,1])
 Legendre(1⋅P₀(x) + 2⋅P₁(x) + 2⋅P₂(x) + 1⋅P₃(x))
 
-julia> rts = roots(p)
-3-element Vector{ComplexF64}:
-                  -1.0 + 0.0im
-  -0.19999999999999987 + 0.0im
- 5.006882873781531e-17 + 0.0im
+julia> rts = roots(p); rts ≈ [-1, -1/5, 0]
+true
 
-julia> p.(rts)
-3-element Vector{ComplexF64}:
-  -2.220446049250313e-16 + 0.0im
- -1.1102230246251565e-16 + 0.0im
-    6.67584383170871e-17 + 0.0im
+julia> maximum(abs∘p, rts) <= 10eps() # small residual
+true
 ```
 
 
@@ -358,14 +352,18 @@ julia> using LinearAlgebra
 julia> p50 = basis(Legendre{Float64}, 50)
 Legendre(1.0⋅P₅₀(x))
 
-julia> as = eigvals(Polynomials.companion(p50)); maximum(abs ∘ p50, as)
-68.26073506641114
+julia> as = eigvals(Polynomials.companion(p50));
 
-julia> bs = eigvals(SpecialPolynomials.jacobi_matrix(Legendre, 50 )); maximum(abs ∘ p50, bs)
-1.84297022087776e-14
+julia> maximum(abs ∘ p50, as) < sqrt(eps())
+false
 
-julia> maximum(abs, roots(p50) - bs)
-5.551115123125783e-16
+julia> bs = eigvals(SpecialPolynomials.jacobi_matrix(Legendre, 50 ));
+
+julia> maximum(abs ∘ p50, bs) < sqrt(eps())
+true
+
+julia> maximum(abs, roots(p50) - bs) < sqrt(eps())
+true
 ```
 
 (The roots of the classic orthogonal polynomials  are  all  real  and distinct.)

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -78,7 +78,7 @@ julia> u = variable(ChebyshevU)
 ChebyshevU(0.5⋅U₁(x))
 
 julia> p3(u)
-ChebyshevU(- 0.125⋅U₁(x) + 0.3125⋅U₃(x))
+ChebyshevU(-0.125⋅U₁(x) + 0.3125⋅U₃(x))
 ```
 
 For most of the orthogonal polynomials, a conversion from the standard basis is provided, and a conversion between different parameter values  for the  same polynomial type are provded. Conversion methods between other polynomial types are not provided, but either evaluation, as above, or conversion through the `Polynomial` type is possible. As possible, for the orthogonal polynomial types, conversion utilizes the `FastTransforms` package; this package can handle conversion between polynomials with very high degree.
@@ -210,10 +210,10 @@ julia> P = Jacobi{1/2, -1/2}
 Jacobi{0.5, -0.5, T, X, N} where {T, X, N}
 
 julia> p,q = P([1,2]), P([-2,1])
-(typename(Jacobi){0.5,-0.5}(1⋅Jᵅᵝ₀(x) + 2⋅Jᵅᵝ₁(x)), typename(Jacobi){0.5,-0.5}(- 2⋅Jᵅᵝ₀(x) + 1⋅Jᵅᵝ₁(x)))
+(typename(Jacobi){0.5,-0.5}(1⋅Jᵅᵝ₀(x) + 2⋅Jᵅᵝ₁(x)), typename(Jacobi){0.5,-0.5}(-2⋅Jᵅᵝ₀(x) + 1⋅Jᵅᵝ₁(x)))
 
 julia> p * q
-typename(Jacobi){0.5,-0.5}(- 1.5⋅Jᵅᵝ₀(x) - 2.0⋅Jᵅᵝ₁(x) + 1.3333333333333333⋅Jᵅᵝ₂(x))
+typename(Jacobi){0.5,-0.5}(-1.5⋅Jᵅᵝ₀(x) -2.0⋅Jᵅᵝ₁(x) + 1.3333333333333333⋅Jᵅᵝ₂(x))
 ```
 
 ### Derivatives and integrals
@@ -237,10 +237,10 @@ julia> P = Jacobi{1//2, -1//2}
 Jacobi{1//2, -1//2, T, X, N} where {T, X, N}
 
 julia> p,q = P([1,2]), P([-2,1])
-(typename(Jacobi){1//2,-1//2}(1⋅Jᵅᵝ₀(x) + 2⋅Jᵅᵝ₁(x)), typename(Jacobi){1//2,-1//2}(- 2⋅Jᵅᵝ₀(x) + 1⋅Jᵅᵝ₁(x)))
+(typename(Jacobi){1//2,-1//2}(1⋅Jᵅᵝ₀(x) + 2⋅Jᵅᵝ₁(x)), typename(Jacobi){1//2,-1//2}(-2⋅Jᵅᵝ₀(x) + 1⋅Jᵅᵝ₁(x)))
 
 julia> p * q # as above, only with rationals for paramters
-typename(Jacobi){1//2,-1//2}(- 1.5⋅Jᵅᵝ₀(x) - 2.0⋅Jᵅᵝ₁(x) + 1.3333333333333333⋅Jᵅᵝ₂(x))
+typename(Jacobi){1//2,-1//2}(-1.5⋅Jᵅᵝ₀(x) -2.0⋅Jᵅᵝ₁(x) + 1.3333333333333333⋅Jᵅᵝ₂(x))
 
 julia> P = Jacobi{1//2, 1//2}
 Jacobi{1//2, 1//2, T, X, N} where {T, X, N}
@@ -290,16 +290,16 @@ julia> p = Legendre([1,2,2,1])
 Legendre(1⋅P₀(x) + 2⋅P₁(x) + 2⋅P₂(x) + 1⋅P₃(x))
 
 julia> rts = roots(p)
-3-element Vector{Float64}:
- -1.0
- -0.20000000000000007
-  0.0
+3-element Vector{ComplexF64}:
+                   -1.0 + 0.0im
+   -0.20000000000000012 + 0.0im
+ 2.1279274638648817e-16 + 0.0im
 
 julia> p.(rts)
-3-element Vector{Float64}:
- -2.220446049250313e-16
-  0.0
-  0.0
+3-element Vector{ComplexF64}:
+ -2.220446049250313e-16 + 0.0im
+                    0.0 + 0.0im
+  6.167905692361979e-17 + 0.0im
 ```
 
 
@@ -320,7 +320,7 @@ julia> q = SP.monic(p) # monic is not exported
 typename(Jacobi){0.5,-0.5}(0.13333333333333333⋅Jᵅᵝ₀(x) + 0.13333333333333333⋅Jᵅᵝ₁(x) + 0.26666666666666666⋅Jᵅᵝ₂(x) + 0.4⋅Jᵅᵝ₃(x))
 
 julia> fromroots(P, roots(q)) - q |> u -> truncate(u, atol=sqrt(eps()))
-typename(Jacobi){0.5,-0.5}(0.0)
+typename(Jacobi){0.5,-0.5}(0.0 + 0.0im)
 ```
 
 For many of the orthogonal polynomials, the roots are found from the *comrade matrix* using a ``\mathcal{O}(n^2)`` algorithm of Aurentz, Vandebril, and Watkins, which computes in a more efficient manner the `eigvals(SpecialPolynomials.comrade_matrix(p))`. Alternatively, in theory roots may be identified from the companion matrix of the polynomial, once expressed in the standard basis. This approach is the fallback approach for other polynomial types, but is prone to numeric issues.
@@ -350,7 +350,7 @@ julia> eigvals(SpecialPolynomials.jacobi_matrix(Legendre, 5))
   0.9061798459386642
 ```
 
-At higher degrees, the difference in  stability comes out:
+At higher degrees, the difference in  stability comes out. For the special case of a basis polynomial, we see this difference in the maximum residual:
 
 ```jldoctest example
 julia> using LinearAlgebra
@@ -358,14 +358,14 @@ julia> using LinearAlgebra
 julia> p50 = basis(Legendre{Float64}, 50)
 Legendre(1.0⋅P₅₀(x))
 
-julia> sum(isreal, eigvals(Polynomials.companion(p50)))
-34
+julia> as = eigvals(Polynomials.companion(p50)); maximum(abs ∘ p50, as)
+68.26073506641114
 
-julia> sum(isreal, roots(p50))
-50
+julia> bs = eigvals(SpecialPolynomials.jacobi_matrix(Legendre, 50 )); maximum(abs ∘ p50, bs)
+1.84297022087776e-14
 
-julia> sum(isreal, eigvals(SpecialPolynomials.jacobi_matrix(Legendre, 50 )))
-50
+julia> maximum(abs, roots(p50) - bs)
+5.551115123125783e-16
 ```
 
 (The roots of the classic orthogonal polynomials  are  all  real  and distinct.)

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -291,15 +291,15 @@ Legendre(1⋅P₀(x) + 2⋅P₁(x) + 2⋅P₂(x) + 1⋅P₃(x))
 
 julia> rts = roots(p)
 3-element Vector{ComplexF64}:
-                   -1.0 + 0.0im
-   -0.20000000000000012 + 0.0im
- 2.1279274638648817e-16 + 0.0im
+                  -1.0 + 0.0im
+  -0.19999999999999987 + 0.0im
+ 5.006882873781531e-17 + 0.0im
 
 julia> p.(rts)
 3-element Vector{ComplexF64}:
- -2.220446049250313e-16 + 0.0im
-                    0.0 + 0.0im
-  6.167905692361979e-17 + 0.0im
+  -2.220446049250313e-16 + 0.0im
+ -1.1102230246251565e-16 + 0.0im
+    6.67584383170871e-17 + 0.0im
 ```
 
 
@@ -334,12 +334,12 @@ julia> p5 = basis(Legendre, 5)
 Legendre(1.0⋅P₅(x))
 
 julia> roots(p5)
-5-element Vector{Float64}:
- -0.9061798459386644
- -0.5384693101056832
-  0.5384693101056831
-  0.9061798459386636
-  0.0
+5-element Vector{ComplexF64}:
+  -0.906179845938664 + 0.0im
+ -0.5384693101056831 + 0.0im
+                 0.0 + 0.0im
+  0.5384693101056831 + 0.0im
+   0.906179845938664 + 0.0im
 
 julia> eigvals(SpecialPolynomials.jacobi_matrix(Legendre, 5))
 5-element Vector{Float64}:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -115,15 +115,15 @@ Example of a [Bezier](https://pomax.github.io/bezierinfo/) curve  (parameterized
 ```@example
 using Plots, Polynomials, SpecialPolynomials
 bs =[[220, 260], [220, 40], [35, 100],  [120, 140]]
-N = length(bs)-1
 
-ρ = sum(bᵢ.*basis(Bernstein{N},i-1) for (i,bᵢ)  ∈ enumerate(bs))
+p = Bernstein(bs)
 ts = range(0, stop=1, length=500)
-p =  plot(ρ[1].(ts), ρ[2].(ts), legend=false)
+ps = p.(ts)
+xs,ys=[[pᵢ[1] for pᵢ ∈ ps], [pᵢ[2] for pᵢ ∈ ps]]
+p = plot(xs, ys, legend=false)
+
 scatter!(p, [b[1] for b in bs], [b[2] for b in bs])
 savefig("bezier.svg"); nothing # hide
 ```
 
 ![](bezier.svg)
-
-

--- a/src/Orthogonal/Laguerre.jl
+++ b/src/Orthogonal/Laguerre.jl
@@ -81,7 +81,7 @@ end
 gauss_nodes_weights(p::Type{P}, n) where {α, P <: Laguerre{α}} =
     FastGaussQuadrature.gausslaguerre(n,α)
 
-        
+
 ## Overrides
 
 # default  connection between Laguerre is popping out  0s
@@ -91,7 +91,7 @@ function Base.iterate(o::Connection{P, Q}, state=nothing) where
 
     k, n = o.k, o.n
 
-    if state == nothing 
+    if state == nothing
         i = k
         i > n && return nothing
     elseif state + 1 > n
@@ -105,7 +105,7 @@ function Base.iterate(o::Connection{P, Q}, state=nothing) where
     N = α - β - 1 + K
 
     return (i, generalized_binomial(N,K)), i
-    
+
 end
 
 

--- a/src/Orthogonal/comrade.jl
+++ b/src/Orthogonal/comrade.jl
@@ -1,0 +1,664 @@
+##  Comrade Matrix
+
+# generate the  matrix for monic polynomial family
+# should have eigvals(comrade_matrix(p)) ≈ roots(convert(Polynomial, p))
+# This isn't exported
+comrade_matrix(p::P) where {P <: AbstractCCOP} = comrade_matrix(P, coeffs(p))
+function comrade_matrix(P, p::Vector{T}) where {T}
+
+    ismonic(P) || throw(ArgumentError("Polynomial type must be monic"))
+
+    # p = [p0,p1, ...,pn]
+    n = length(p) - 1
+    p ./= p[end] # p is monic
+
+    As = An.(P, 0:n-1)
+    Bs = Bn.(P, 0:n-1)
+    Cs = Cn.(P, 1:n-1)
+
+
+    A = diagm(1 => T.(reverse(Cs ./ As[2:end])), 0 => -T.(reverse(Bs ./ As)), -1 => T.(reverse(1 ./ As[2:end])))
+    A[1,:] -= p[end-1:-1:1]/p[end] * 1/An(P,n)
+
+    A
+end
+
+## -----
+
+## Implement algorithm for eigenvalue of a comrade matrix from:
+## Fast computation of eigenvalues of companion, comrade, and related matrices
+## Jared L. Aurentz · Raf Vandebril · David S. Watkins
+
+## Overlap with AMRVW.jl, but not really, as this paper uses different transforms:
+## * a general 2x2 core transformation
+## * a GaussTransform of the type `[1 0; m 1]`
+
+abstract type AbstractTransform{T} end
+# Ci CoreTransform [c 1; 1 0]
+struct CoreTransform{T} <: AbstractTransform{T}
+    g11::T
+    g12::T
+    g21::T
+    g22::T
+end
+CoreTransform(m::Matrix) = CoreTransform(m[1,1], m[1,2], m[2,1], m[2,2])
+LinearAlgebra.norm(c::CoreTransform) = maximum(abs, splat(c))
+Base.isnan(c::CoreTransform) = isnan(c.g12) || isnan(c.g22) || isnan(c.g21) || isnan(c.g11)
+
+
+# Gi GaussTransform [1 0, m 1]
+struct GaussTransform{T} <: AbstractTransform{T}
+    m::T
+end
+
+splat(c::CoreTransform) = (c.g11, c.g12, c.g21, c.g22)
+splat(c::GaussTransform{T}) where {T}  = (one(T), zero(T), c.m, one(T))
+
+function Base.inv(c::CoreTransform)
+    b11,b12,b21,b22 = splat(c)
+    Δ = b11 * b22 - b12 * b21
+    CoreTransform(b22/Δ, -b12/Δ, -b21/Δ, b11/Δ)
+end
+
+Base.inv(g::GaussTransform) = GaussTransform(-g.m)
+
+
+# overwrite R
+# non-allocating would be better!
+function LinearAlgebra.lmul!(c::AbstractTransform, R, i)
+    ri = copy(R[i,:])
+    c11,c12,c21,c22 = splat(c)
+    R[i,:] = R[i,:] * c11 + R[i+1,:] * c12
+    R[i+1,:] = ri * c21 + R[i+1,:] * c22
+    nothing
+end
+
+
+## -----
+
+
+# In SpecialPolynomials we have P_{n+1} = (An*x + Bn) * P_n + Cn P_{n-1}
+# In paper, we have
+# αₖ pₖ = (z  - βₖ) ⋅ pₖ₋₁ - γₖ ⋅ pₖ₋₂
+## Decompose p::P into Cs, B where
+## * Cs -- a vector of Gauss Transfroms
+## * B -- an Upper triangular matrix
+## Matrix(Cs, B) is comrade matrix
+function decompose(P::Type{<:AbstractCCOP}, ps)
+
+    @assert ismonic(P)
+
+    n = length(ps) - 1
+    As = An.(P, 0:n)
+    Bs = Bn.(P, 0:n-1)
+    Cs = Cn.(P, 1:n-1)
+
+    p̂s = copy(ps)
+
+    # αs = [1/A0, 1/A1, ..., 1/An-2]
+    # βs = [B0/A0, ..., Bn-1/An-1]
+    # γs = [C1/A1, ..., Cn-1/An-1]
+    # cs [ 0 ... 0 γ[end] β[end]] - ps[1:end-1]/ps[end] / An-1
+
+
+    aₙ = pop!(As)
+    βs = -Bs ./ As
+    βn = pop!(βs)
+    γs = [Cs[i]/As[i+1] for i ∈ 1:length(Cs)]
+    γn = pop!(γs)
+    αs = 1 ./ As
+
+    p̂n = pop!(p̂s)
+    p̂s ./= p̂n
+    p̂s *= -aₙ
+    p̂s[end-1] += γn
+    p̂s[end] += βn
+
+    decompose(p̂s, αs, βs, γs)
+
+end
+
+# The comrade matrix is the following (though the paper flips it for Gaussian elimination)
+# [β₁ γ₂ .  .  c₀;
+#  α₁ β₂ γ₃ .  c₁;
+#  .  α₂ β₃ γ₄ c₂;
+#  .  .  α₃ β₄ c₃;
+#  .  .  .  α₄ c₄]
+# returns Cs, B with eigvals(C1 ⋅ C2 ⋅ ⋯ ⋅ Cn * B) = roots(P(p))
+function decompose(cs::Vector{T}, αs, βs, γs) where {T}
+
+
+    n = length(cs)
+    R = zeros(T, n, n)
+
+    CTs = Vector{CoreTransform{T}}(undef, n-1)
+
+    ĉ₀, ĉ₁ = cs[end+1-1], cs[end+1-2]
+
+    for i ∈ 1:n-2
+        λ = ĉ₀ / αs[end+1-i]
+        ĉ₀ = ĉ₁ - λ * βs[end+1-i]
+        ĉ₁ = cs[end+1 - (i+2)] - λ * γs[end+1-i]
+        CTs[i] = CoreTransform(λ, one(T), one(T), zero(T))
+    end
+    λ = ĉ₀ / αs[1]
+    CTs[end] = CoreTransform(λ, one(T), one(T), zero(T))
+    ĉ₀ = ĉ₁ - λ * βs[1]
+
+    for i ∈ 1:n-2
+        R[i, i]   = αs[end+1-i]
+        R[i, i+1] = βs[end+1-i]
+        R[i, i+2] = γs[end+1-i]
+    end
+
+    R[n-1, n-1] = αs[1]
+    R[n-1, n] = βs[1]
+    R[n,n] = ĉ₀
+
+    CTs, R
+end
+
+
+
+## ----- primary operations with CoreTransforms
+
+# type 1
+function turnover(Ci::CoreTransform,Ci1::CoreTransform,Gi::GaussTransform)
+    a11,a12,a21,a22 = splat(Ci)
+    b22,b23, b32, b33 = splat(Ci1)
+    g21 = Gi.m
+
+    â11 = a11 + a12 * (b22*g21)
+    â12 = a12
+    â21 = a21 + a22 * (b22 * g21)
+    â22 = a22
+
+    ĝ32 = b32 * g21 / â21
+
+    b̂22 = b22
+    b̂23 = b23
+    b̂32 = b32 - (ĝ32 * a22) * b22
+    b̂33 = b33 - (ĝ32 * a22) * b23
+
+    GaussTransform(ĝ32), CoreTransform(â11,â12,â21,â22), CoreTransform(b̂22,b̂23,b̂32,b̂33)
+
+end
+
+# type 2
+function turnover(Gi::GaussTransform, Gi1::GaussTransform, Ci::CoreTransform)
+    a21 = Gi.m
+    b32 = Gi1.m
+    g11,g12,g21,g22 = Ci.g11,Ci.g12,Ci.g21,Ci.g22
+
+    â11 = g11
+    â12 = g12
+    â21 = g21 + a21 * g11
+    â22 = g22 + a21 * g12
+
+    ĝ32 = b32*g21/â21
+    b̂32 = b32*g22 - ĝ32*â22
+
+    GaussTransform(ĝ32), CoreTransform(â11, â12, â21, â22), GaussTransform(b̂32)
+
+end
+
+# type 3
+function turnover(Gi::GaussTransform, Gi1::GaussTransform, G′i::GaussTransform)
+    a21 = Gi.m
+    b32 = Gi1.m
+    g21 = G′i.m
+
+    â21 = a21 + g21
+    ĝ32 = b32 * g21 / â21
+    b̂32 = b32 - ĝ32
+
+    GaussTransform(ĝ32), GaussTransform(â21), GaussTransform(b̂32)
+end
+
+function fuse(c::CoreTransform, g::GaussTransform)
+    a11,a12,a21,a22 = splat(c)
+    m = g.m
+    CoreTransform(a11 + a12 * m, a12,
+                  a21 + a22 * m, a22)
+end
+
+function fuse(g::GaussTransform, c::CoreTransform)
+    m = g.m
+    a11,a12,a21,a22 = splat(c)
+
+    CoreTransform(a11,         a12,
+                  a11*m + a21, a12*m + a22)
+end
+
+function fuse(g1::GaussTransform, g2::GaussTransform)
+    GaussTransform(g1.m + g2.m)
+end
+
+# Rlᵢ -> l′ᵢR′
+# modifies R; returns l′ᵢ
+function passthrough!(R, l, i)
+    m = l.m
+
+    m′ = -m * R[i+1,i+1]/(R[i,i] + R[i,i+1]*m)
+
+    for j ∈ 1:i+1
+        R[j,i] += m * R[j,i+1] # R[:,i]   += m * R[:,i+1]  # R * Gᵢ
+    end
+    for j ∈ i:size(R)[2]
+        R[i+1, j]  += m′ * R[i,j] # R[i+1,:] += m′ * R[i,:] # Ĝᵢ * R
+    end
+
+    R[i+1,i] = 0 # may accumulate round off
+
+    GaussTransform(-m′)
+
+end
+
+## ---- initial shift
+
+# get eigenvalues of lower 2x2 matrix of A = Cs * B
+function lower_eigs(Cs, R::Matrix{T}, n=length(Cs)) where {T}
+
+    cn11, cn12, cn21, cn22 = splat(Cs[n])
+
+    if n >= 2
+        cn1_11, cn1_12, cn1_21, cn1_22 = splat(Cs[n-1])
+
+        u11 = cn1_21 * R[n-1,n] + cn1_22 * cn11 * R[n,n]
+        u12 = cn1_21*R[n-1,n+1] + cn1_22 * cn11 * R[n,n+1] + cn1_22 * cn12 * R[n+1, n+1]
+        u21 = cn21 * R[n,n]
+        u22 = cn21 * R[n,n+1] + cn22 * R[n+1,n+1]
+
+    else
+        u11 = cn11 * R[1,1]
+        u12 = cn11 * R[1,2] + cn12 * R[2,2]
+        u21 = zero(T)
+        u22 = cn22 * R[2,2]
+    end
+
+    ρ1, ρ2 = eigen_values(u11, u12, u21, u22)
+    ρ1, ρ2
+end
+
+
+# We create bulge through Â L⁻¹ A L and chase it down through as sequence of
+# unitary operations of the type G⁻¹ Â G, G a Gauss transform
+
+L(Cs, R::Matrix{T}, random::Bool=false) where {T <: Complex} = L1(Cs, R, random)
+L(Cs, R::Matrix{T}, random::Bool=false) where {T}  = L1L2(Cs, R, random)
+
+function L1(Cs, R::Matrix{T}, random::Bool=false) where {T}
+    random && return GaussTransform(rand(T))
+
+    c11,c12,c21,c22 = splat(Cs[1])
+    r11 = R[1,1]
+    a11, a21 = c11*r11, c21*r11
+
+    ρs = lower_eigs(Cs, R)
+    ρ1 = norm(a21 - ρs[1]) < norm(a21 - ρs[2]) ? ρs[1] : ρs[2]
+
+    m = a21 / (a11 - ρ1)
+    GaussTransform(m)
+end
+
+function L1L2(Cs,R::Matrix{T}, random::Bool=false) where {T}
+    random && return (GaussTransform(rand(T)), GaussTransform(rand(T)))
+
+    ρ1, ρ2 = lower_eigs(Cs, R)
+
+    ρ1ρ2 = real(ρ1*ρ2)
+    ρ1_ρ2 = real(ρ1 + ρ2)
+
+
+    cn11,cn12,cn21,cn22 = splat(Cs[2])
+    cn1_11,cn1_12, cn1_21, cn1_22 = splat(Cs[1])
+
+    a11 = cn1_11 * R[1,1]
+    a12 = cn1_11 * R[1,2] + cn1_12 * cn11 * R[2,2]
+    a21 = cn1_21 * R[1,1]
+    a22 = cn1_21 * R[1,2] + cn1_22 * cn11 * R[2,2]
+    a32 = cn21 * R[2,2]
+
+    x1 = a11^2 +  a12 * a21 - ρ1_ρ2*a11 + ρ1ρ2
+    x2 = a21 * a11 + a22 * a21 - ρ1_ρ2*a21
+    x3 = a32 * a21
+    m1 = x2/x1
+    m2 = x3/x2
+
+    # return l1, l2 (L = L2 * L1 though)
+    GaussTransform(m1), GaussTransform(m2)
+
+end
+
+
+# single-shift bulge chase
+# updates Cs, R
+function chase_bulge!(Cs, R, l1::GaussTransform)
+    n = length(Cs)
+    Cs[1] = fuse(inv(l1), Cs[1])
+    for i ∈ 1:n-1
+        l1 = passthrough!(R, l1, i)
+        l1, Cs[i], Cs[i+1] = turnover(Cs[i],Cs[i+1], l1)
+    end
+    l1 = passthrough!(R, l1, n)
+    Cs[n] = fuse(Cs[n], l1)
+    nothing
+end
+
+# double-shift bulge chase
+function chase_bulge!(Cs, R, l1l2::Tuple)
+    n = length(Cs)
+
+    l1, l2 = l1l2
+    l1′, l2′ = inv(l1), inv(l2)
+    l1′, Cs[1], l2′ = turnover(l1′, l2′, Cs[1])
+    Cs[2] = fuse(l2′, Cs[2])
+
+    for i in 1:n-2
+
+        l2 = passthrough!(R, l2, i+1)
+        l2, Cs[i+1], Cs[i+2] = turnover(Cs[i+1], Cs[i+2], l2)
+
+        l1 = passthrough!(R, l1, i)
+        l1, Cs[i], Cs[i+1] = turnover(Cs[i], Cs[i+1], l1)
+
+        l2, l1, l1′ = turnover(l1′, l2, l1)
+
+    end
+    # knit in ends
+    l2 = passthrough!(R, l2, n)
+    Cs[n] = fuse(Cs[n], l2)
+
+
+    l1 = passthrough!(R, l1, n-1)
+    l1, Cs[n-1], Cs[n] = turnover(Cs[n-1], Cs[n], l1)
+
+
+    l1 = fuse(l1′, l1)
+    l1 = passthrough!(R, l1, n)
+    Cs[n] = fuse(Cs[n], l1)
+
+    nothing
+end
+
+# find roots of P(p) without converting into standard basis
+# using comrade_matrix
+"""
+    roots(p::P) where {P <: AbstractCCOP}
+
+When `P` is a monic family, finds the roots of `p` using the comrade matrix; otherwise falls back to finding the roots after conversion to the `Polynomial` type.
+
+The eigenvalue of the comrade matrix are identified using an algorithm from
+
+*Fast computation of eigenvalues of companion, comrade, and related matrices*
+by Jared L. Aurentz, Raf Vandebril, and David S. Watkins
+DOI 10.1007/s10543-013-0449-x
+BIT Numer Math (2014) 54:7–30
+
+The paper presents both a single- and double-shift version. The paper
+has this caveat: "The double-shift code was less successful. It too is
+very fast, but it is too unstable in its current form. We cannot
+recommend it for accurate computation of roots of high-degree
+polynomials. It could find use as an extremely fast method to get a
+rough estimate of the spectrum"
+
+"""
+Polynomials.roots(p::P) where {P <: AbstractOrthogonalPolynomial} =
+    roots(Val(ismonic(P)), p)
+
+function Polynomials.roots(ISMONIC::Val{true}, p::P) where {P <: AbstractOrthogonalPolynomial}
+    λs = roots(P, coeffs(p))
+    newton_refinement(λs, p)
+end
+
+function Polynomials.roots(ISMONIC::Val{false}, p::P) where {T, P <: AbstractOrthogonalPolynomial{T}}
+    q = convert(Polynomial{T}, p)
+    roots(q)
+end
+
+
+function Polynomials.roots(P::Type{<:AbstractCCOP}, p::Vector{T}) where {T}
+
+    Cs, B = decompose(P, p)
+
+    max_ctr = 1
+    ctr = 1
+    while length(Cs) > 1
+
+        # get L # random if no deflation
+        if ctr < 15
+            ctr += 1
+            l = L(Cs, B)
+        else
+            l = L(Cs, B, true) # random=true
+            ctr = 1
+        end
+
+        chase_bulge!(Cs, B, l)
+        deflateQ!(Cs, B) && (ctr = 0)
+
+        # check runaway
+        max_ctr += 1
+        (!isempty(Cs) && isnan(Cs[end])) && error("NaN")
+        max_ctr > 1000 && error("Failure to converge, too many steps")
+
+    end
+
+    !isempty(Cs) && lmul!(Cs[1], B, 1)
+
+    _eigvals(B)
+
+end
+
+# modifies Cs and B on deflation
+# return true if deflation
+# we deflate when off-diagonal entry < ϵ
+# paper would have |aₙ₊₁,ₙ| ≤ eps() * (|aₙ,ₙ| + |aₙ₊₁,ₙ₊₁|)
+# but we just use eps()^(2/3) which seems to work better for Float64
+function deflateQ!(Cs, B::Matrix{T}) where {T}
+    # simple case
+    # is aₙ₊₁,ₙ < eps(T)(|ann| + |an+1,n+1|)
+    n = length(Cs)
+
+    c_11, c_12, c_21, c_22 = splat(Cs[n])
+    c1_11, c1_12, c1_21, c1_22 = n > 1 ? splat(Cs[n-1]) : (zero(T), zero(T), zero(T), zero(T))
+
+
+    Rn_1n = n > 1 ? B[n-1,n] : zero(T)
+
+    an1_n = c_21 * B[n,n]
+    ann = c1_21 * Rn_1n + c1_22 * c_11 * B[n,n]
+    an1n1 = c_21 * B[n,n+1] + c_22 * B[n+1,n+1]
+
+    ϵ = cbrt(eps(real(T))^2)
+
+    #if norm(an1_n) <=  ϵ * (norm(ann) + norm(an1n1))
+    if norm(an1_n) <=  ϵ
+        n = length(Cs)
+        c = pop!(Cs)
+        lmul!(c, B, n)
+        return true
+    end
+
+    !(T <: Real) && return false
+    n == 1 && return false
+
+    c2_11, c2_12, c2_21, c2_22 = n > 2 ? splat(Cs[n-2]) : (zero(T), zero(T), zero(T), zero(T))
+    Rn_1n_1 = n > 1 ? B[n-1, n-1] : zero(T)
+    Rn_2n_1 = n > 2 ? B[n-2, n-1] : zero(T)
+    ann_1 = c1_21 * Rn_1n_1
+    an_1n_1 = c1_11 * c2_22 * Rn_1n_1 + c2_21 * Rn_2n_1
+
+    # if norm(ann_1) <=  eps(real(T)) * (norm(an_1n_1) + norm(ann))
+    if norm(ann_1) <=  ϵ
+        A = Matrix(Cs, B)
+        n = length(Cs)
+        c = pop!(Cs)
+        lmul!(c, B, n)
+        c = pop!(Cs)
+        lmul!(c, B, n-1)
+        return true
+    end
+
+    return false
+end
+
+# grab eigenvalues from B
+function _eigvals(B::Matrix{T}) where {T}
+    m = size(B)[1]
+    es = Vector{complex(T)}(undef, m)
+    i = 1
+
+    #ϵ = 1000 * eps(real(T))
+    ϵ = cbrt(eps(real(T))^2)
+    while i < m
+        #if abs(B[i+1,i]) <= ϵ * (norm(B[i,i]) + norm(B[i+1,i+1]))
+        if abs(B[i+1,i]) <= ϵ
+            es[i] = B[i,i]
+            i += 1
+        else
+            r1, r2 = eigen_values(B[i,i], B[i,i+1], B[i+1,i], B[i+1,i+1])
+            es[i] = r1
+            es[i+1] = r2
+            i += 2
+        end
+    end
+
+    i == m && (es[end] = B[end,end])
+
+    LinearAlgebra.sorteig!(es)
+    es
+end
+
+# one step improves accuracy
+function newton_refinement(λs, p::P)  where {P <: AbstractCCOP}
+    @assert ismonic(P)
+    p′ = derivative(p)
+    λs .- p.(λs) ./ p′.(λs)
+end
+
+
+## -----
+## from AMRVW
+# altrnative to eigvals that works with other types
+function  eigen_values(a11::T, a12::T, a21::T, a22::T) where {T <: Real}
+    b = (a11 + a22) / 2
+    c = a11 * a22 - a12 * a21
+
+    e1r, e1i, e2r, e2i = qdrtc(b,c) #qdrtc(one(b), b, c)
+    return  complex(e1r, e1i), complex(e2r, e2i)
+
+end
+
+# from `modified_quadratic.f90`
+function  eigen_values(a11::S, a12::S, a21::S, a22::S) where {S <: Complex}
+
+    tr = a11 + a22
+    detm = a11 * a22 - a21 * a12
+    disc::S = sqrt(tr * tr - 4.0 * detm)
+
+    u::S = abs(tr + disc) > abs(tr - disc) ? tr + disc : tr - disc
+    if iszero(u)
+        return zero(S), zero(S)
+    else
+        e1::S = u / 2.0
+        e2::S = detm / e1
+        return e1, e2
+    end
+
+end
+
+## Kahan quadratic equation with fma
+##  https://people.eecs.berkeley.edu/~wkahan/Qdrtcs.pdf
+
+## solve ax^2 - 2bx + c
+function qdrtc(a::T, b::T, c::T) where {T <: Real}
+    # z1, z2 roots of ax^2 - 2bx + c
+    d = discr(a,b,c)  # (b^2 - a*c), as 2 removes 4
+
+    if d <= 0
+        r = b/a  # real
+        s = sqrt(-d)/a #imag
+        return (r,s,r,-s)
+    else
+        r = sqrt(d) * (sign(b) + iszero(b)) + b
+        return (r/a, zero(T), c/r, zero(T))
+    end
+end
+
+## more work could be done here.
+function discr(a::T,b::T,c::T) where {T}
+    pie = 3.0 # depends on 53 or 64 bit...
+    d = b*b - a*c
+    e = b*b + a*c
+
+    pie*abs(d) > e && return d
+
+    p = b*b
+    dp = muladd(b,b,-p)
+    q = a*c
+    dq = muladd(a,c,-q)
+
+    (p-q) + (dp - dq)
+end
+
+function qdrtc(b::T, c::T) where {T <: Real}
+    d = b*b - c
+    if d <= 0
+        r = b  # real
+        s = sqrt(-d) #imag
+        return (r,s,r,-s)
+    else
+        r = sqrt(d) * (sign(b) + iszero(b)) + b
+        return (r, zero(T), c/r, zero(T))
+    end
+end
+
+## -----
+
+## test root quality
+function a_posteriori_check(λs, p::P) where {P <: AbstractCCOP}
+    @assert ismonic(P)
+    ps = coeffs(p)
+    n = length(ps) - 1
+    v(λ) = [basis(P, i)(λ) for i ∈ n-1:-1:0]
+    αₙ = 1/An(P,  n - 1)
+    cₙ = ps[end-1]/ps[end] / αₙ
+    p = P(ps)
+    A = comrade_matrix(P,ps)
+    Aₒₒ = norm(A, Inf)
+    [norm(αₙ * p(λ) / cₙ) /  (Aₒₒ * norm(v(λ), Inf)) for λ ∈ λs]
+end
+
+## ----
+
+# Helpful for developing
+function Base.show(io::IO, c::AbstractTransform)
+    c11,c12,c21,c22 = splat(c)
+    show(IOContext(io, :compact => true), "text/plain", [c11 c12;
+                                                         c21 c22])
+    println(io)
+end
+
+
+## realize transform as a matrix
+function realize(c::AbstractTransform{T}, i, n) where {T}
+    A = diagm(0 => ones(T, n))
+    a,b,c,d = splat(c)
+    A[i,i] = a
+    A[i,i+1] = b
+    A[i+1,i] = c
+    A[i+1,i+1] = d
+    A
+end
+
+function Base.Matrix(Cs, B)
+    n = length(Cs)
+    m = size(B)[1]
+    for i ∈ n:-1:1
+        B = realize(Cs[i], i,m)*B
+    end
+    B
+end
+
+#end

--- a/src/Orthogonal/comrade.jl
+++ b/src/Orthogonal/comrade.jl
@@ -2,7 +2,7 @@
 ## The comrade matrix plays the role of the companion matrix for static basis polynomials
 
 #
-# generate the  matrix for monic polynomial family
+# generate the  matrix for an orhtogonal polynomial family
 # should have eigvals(comrade_matrix(p)) ≈ roots(convert(Polynomial, p))
 # This isn't exported
 function comrade_matrix(p::P) where {P <: AbstractCCOP}
@@ -15,10 +15,11 @@ end
 # can be used with square matrix coefficients
 function comrade_pencil(p::P, symmetrize=false) where {T, P <: AbstractCCOP{T}}
     n = Polynomials.degree(p)
-    𝐏 = ⟒(P)
-    As = An.(𝐏{T}, 0:n-1)
-    Bs = Bn.(𝐏{T}, 0:n-1)
-    Cs = Cn.(𝐏{T}, 1:n-1)
+    𝐏 = _comrade_pencil_type(p)
+
+    As = An.(𝐏, 0:n-1)
+    Bs = Bn.(𝐏, 0:n-1)
+    Cs = Cn.(𝐏, 1:n-1)
     kₙ, kₙ₋₁ = leading_term(𝐏{T}, n), leading_term(𝐏{T},n-1)
 
     # α = 1/A
@@ -32,6 +33,8 @@ function comrade_pencil(p::P, symmetrize=false) where {T, P <: AbstractCCOP{T}}
 
     comrade_pencil(p, α, β, γ, kₙ₋₁, kₙ, symmetrize)
 end
+_comrade_pencil_type(p::P) where {T, P <: AbstractCCOP{T}} =  ⟒(P){T}
+_comrade_pencil_type(p::P) where {T, M<: AbstractMatrix{T}, P <: AbstractCCOP{M}} = ⟒(P){T}
 
 # α = [α₀, α₁, ⋯, αₙ₋₂]
 # β = [β₀, β₁, ⋯, βₙ₋₂, βₙ₋₁]
@@ -531,7 +534,6 @@ end
 
 # one step improves accuracy
 function newton_refinement(λs, p::P)  where {P <: AbstractCCOP}
-    #@assert ismonic(P)
     p′ = derivative(p)
     λs .- p.(λs) ./ p′.(λs)
 end
@@ -623,8 +625,6 @@ end
 ## Matrix(Cs, B) is comrade matrix
 function comrade_decomposition(P::Type{<:AbstractCCOP}, ps)
 
-#    @assert ismonic(P)
-
     n = length(ps) - 1
     As = An.(P, 0:n-1)
     Bs = Bn.(P, 0:n-1)
@@ -703,7 +703,7 @@ end
 """
     roots(p::P) where {P <: AbstractCCOP}
 
-When `P` is a monic family, finds the roots of `p` using the comrade matrix; otherwise falls back to finding the roots after conversion to the `Polynomial` type.
+When `P` is a classical orthogonal family, finds the roots of `p` using the comrade matrix; otherwise falls back to finding the roots after conversion to the `Polynomial` type.
 
 The eigenvalue of the comrade matrix are identified using an algorithm from
 
@@ -739,8 +739,8 @@ end
 ## -----
 
 ## test root quality
+## could presumably be much more efficient
 function a_posteriori_check(λs, p::P) where {P <: AbstractCCOP}
-#    @assert ismonic(P)
     ps = coeffs(p)
     n = length(ps) - 1
     v(λ) = [basis(P, i)(λ) for i ∈ n-1:-1:0]

--- a/src/Orthogonal/connection.jl
+++ b/src/Orthogonal/connection.jl
@@ -38,8 +38,8 @@
 ConvertibleTypes = Union{AbstractCOP, Polynomials.StandardBasisPolynomial,  FallingFactorial}
 kn(::Type{P},  n) where{P <: Union{Polynomials.StandardBasisPolynomial,  FallingFactorial}} = one(eltype(one(P)))
 k1k0(::Type{P},  n) where{P <: Union{Polynomials.StandardBasisPolynomial,  FallingFactorial}} = one(eltype(one(P)))
-knk_1(::Type{P},  n) where{P <: Union{Polynomials.StandardBasisPolynomial,  FallingFactorial}} = one(eltype(one(P))) 
-                         
+knk_1(::Type{P},  n) where{P <: Union{Polynomials.StandardBasisPolynomial,  FallingFactorial}} = one(eltype(one(P)))
+
 
 
 ## If  the connection  coefficients for  (P,Q) satisfy c₀⋅ C̃ⁱⱼ + c₁⋅C̃ⁱ⁺¹ⱼ  + c₂⋅*C̃ⁱ⁺²ⱼ = 0 for some computable
@@ -49,22 +49,22 @@ function _convert_cop(::Type{Q}, p::P) where {P <: ConvertibleTypes,
 
     d = degree(p)
     T,S = eltype(Q), eltype(p)  #
-    R = typeof(one(promote_type(T,S))/1)
-
+    R = typeof(one(T) * p[0]/1)
     as = zeros(R, 1+d)
 
     λⱼⱼ = one(R)  * k0(P) / k0(Q)
-    
+
+
     for j in  0:d
 
-        λ = λⱼⱼ 
+        λ = λⱼⱼ
 
-        λⱼⱼ *= k1k0(P,j) / k1k0(Q,j)  
+        λⱼⱼ *= k1k0(P,j) / k1k0(Q,j)
 
         pⱼ = p[j]
         iszero(pⱼ) && continue
 
-        C̃ʲⱼ = one(R)  
+        C̃ʲⱼ = one(R)
 
         as[1+j] += pⱼ * (λ * C̃ʲⱼ)
 
@@ -112,22 +112,22 @@ end
 #     Q <: Union{Gegenbauer{β}, OrthonormalGegenbauer{β}},
 #     P <: Union{Gegenbauer{α, T}, OrthonormalGegenbauer{α, T}}
 # }
-    
+
 #     ps =  coeffs(p)
 #     Q( ultra2ultra(ps, α, β, norm1=isorthonormal(P), norm2=isorthonormal(Q)) )
-       
+
 # end
-       
+
 # # Jacobi<--Jacobi
 # function _convert(::Type{Q}, p::P) where {
 #     γ, δ, α, β,  T <: AbstractFloat,
 #     Q <: Union{Jacobi{γ, δ}, OrthonormalJacobi{γ, δ}},
 #     P <: Union{Jacobi{α, β, T}, OrthonormalJacobi{α, β, T}}
 # }
-    
+
 #     ps =  coeffs(p)
 #     Q( jac2jac(ps, α, β, γ, δ,  norm1=isorthonormal(P), norm2=isorthonormal(Q)) )
-    
+
 # end
 
 # # Laguerre<--Laguerre
@@ -139,7 +139,7 @@ end
 
 #     ps =  coeffs(p)
 #     Q( lag2lag(ps, α, β,  norm1=isorthonormal(P), norm2=isorthonormal(Q)) )
-    
+
 # end
 
 
@@ -149,10 +149,10 @@ end
 #     Q <: Union{Jacobi{γ, δ}, OrthonormalJacobi{γ, δ}},
 #     P <: Union{Gegenbauer{α, T}, OrthonormalGegenbauer{α, T}}
 # }
-    
+
 #     ps =  coeffs(p)
 #     Q( ultra2jac(ps, α, γ, δ,  normultra=isorthonormal(P), normjac=isorthonormal(Q)) )
-    
+
 # end
 
 # # ultraspherical<--Jacobi
@@ -161,10 +161,10 @@ end
 #     Q <: Union{Gegenbauer{α, T}, OrthonormalGegenbauer{α, T}},
 #     P <: Union{Jacobi{γ, δ}, OrthonormalJacobi{γ, δ}}
 # }
-    
+
 #     ps =  coeffs(p)
 #     Q( jac2ultra(ps,γ, δ, α, normjac=isorthonormal(P), normultra=isorthonormal(Q)) )
-    
+
 # end
 
 # # Jacobi<--Chebyshev
@@ -173,10 +173,10 @@ end
 #     Q <: Union{Jacobi{γ, δ}, OrthonormalJacobi{γ, δ}},
 #     P <: Union{Chebyshev{T}, OrthonormalChebyshev{T}}
 # }
-    
+
 #     ps =  coeffs(p)
 #     Q( cheb2jac(ps,γ, δ, normcheb=isorthonormal(P), normjac=isorthonormal(Q)) )
-    
+
 # end
 
 # # Chebyshev<--Jacobi
@@ -185,10 +185,10 @@ end
 #     Q <: Union{Chebyshev, OrthonormalChebyshev},
 #     P <: Union{Jacobi{γ, δ,T}, OrthonormalJacobi{γ, δ,T}}
 # }
-    
+
 #     ps =  coeffs(p)
 #     Q( jac2cheb(ps,γ, δ, normjac = isorthonormal(P), normcheb=isorthonormal(Q)) )
-    
+
 # end
 
 # # ultraspherical<--Chebyshev
@@ -200,7 +200,7 @@ end
 
 #     ps =  coeffs(p)
 #     Q( cheb2ultra(ps,α, normcheb=isorthonormal(P), normultra=isorthonormal(Q)) )
-    
+
 # end
 
 # # Chebyshev<--ultraspherical
@@ -211,7 +211,7 @@ end
 # }
 #     ps =  coeffs(p)
 #     Q( ultra2cheb(ps,α, normultra=isorthonormal(P), normcheb=isorthonormal(Q)) )
-    
+
 # end
 
 
@@ -225,7 +225,7 @@ function connection_m(::Type{P},::Type{Q},m,n) where {
 
     (a == ā && b == b̄ && c == c̄) || throw(ArgumentError("This connection assume σ = σ̄"))
     a²,b²,c²,d²,d̄²,e²,ē²,m²,n² = a^2, b^2, c^2, d^2, d̄^2, e^2, ē^2, m^2, n^2
-    
+
     c0 = -(m-n) ⋅ (a⋅m + d - a + a⋅n) ⋅ (d̄ + 2a⋅m) ⋅ (d̄ + a + 2a⋅m) ⋅ (d̄ + 3a + 2a⋅m)
     c0 *= (d̄ + 2a⋅m  + 2a)^2
 
@@ -240,7 +240,7 @@ function connection_m(::Type{P},::Type{Q},m,n) where {
     c2a += b⋅ē⋅d̄ - 4⋅a²⋅c + b²⋅d̄
     c2 *= c2a ⋅ (m + 2)
 
-    
+
     return (c0, c1, c2)
 
 end
@@ -257,7 +257,7 @@ function connection_m(::Type{P},::Type{Q},m,n) where {
     c1 = (m + 1) ⋅ (b⋅m + e)
 
     c2 = c ⋅ (m + 1) ⋅ (m + 2)
-                  
+
     return (c0, c1, c2)
 
 end
@@ -269,7 +269,7 @@ function connection_m(::Type{P},::Type{Q},m,n) where {
 
     ā,b̄,c̄,d̄,ē = abcde(Q)
     ā²,b̄²,c̄²,d̄²,ē²,m²,n² = ā^2, b̄^2, c̄^2, d̄^2, ē^2, m^2, n^2
-    
+
     c0 =  (n - m) ⋅ (d̄ + 2ā⋅m) ⋅ (d̄ + 3ā + 2ā⋅m) ⋅ (d̄ + ā + 2ā⋅m) ⋅ (d̄ + 2ā⋅m + 2ā)^2
 
     c1 =  (d̄⋅ē + b̄⋅d̄ +2d̄⋅b̄⋅m + 2ā⋅m²⋅b̄ + 2ā⋅m⋅b̄ +2ē⋅ā⋅n - d̄⋅b̄⋅n) ⋅ (d̄ + 2ā⋅m + 2ā)
@@ -289,7 +289,7 @@ end
 function connection(::Type{P}, q::Q) where
     {P <: Polynomials.AbstractPolynomial,
      Q<:Polynomials.AbstractPolynomial}
-    
+
     n = degree(q)
     T = eltype(q)
     T = eltype(one(eltype(one(P)))*one(q)/1)
@@ -302,6 +302,5 @@ function connection(::Type{P}, q::Q) where
     end
     X = Polynomials.indeterminate(P,q)
     ⟒(P){T,X}(cs)
-    
-end
 
+end

--- a/src/SpecialPolynomials.jl
+++ b/src/SpecialPolynomials.jl
@@ -48,6 +48,7 @@ include("Orthogonal/Discrete/DiscreteChebyshev.jl")
 
 include("Orthogonal/connection.jl")
 include("Orthogonal/glaser-liu-rokhlin.jl")
+include("Orthogonal/comrade.jl")
 
 
 include("Interpolating/interpolating.jl")

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -3,9 +3,9 @@
 
 An abstract type to distinguish the different polynomial types in this package.
 
-The concrete types specify different bases for the space of polynomials of degree `n` or less. 
+The concrete types specify different bases for the space of polynomials of degree `n` or less.
 
-This package includes: 
+This package includes:
 
 * several classic orthogonal polynomials.
 * Newton and Lagrange interpolating polynomials
@@ -26,7 +26,7 @@ Base.eltype(::Type{<:AbstractSpecialPolynomial}) = Float64
 @generated function constructorof(::Type{T}) where T
       getfield(parentmodule(T), nameof(T))
  end
-⟒(P::Type{<:AbstractSpecialPolynomial}) = constructorof(P) 
+⟒(P::Type{<:AbstractSpecialPolynomial}) = constructorof(P)
 ⟒(::Type{<:Polynomial}) = Polynomial
 
 ## Display
@@ -41,8 +41,14 @@ end
 function Polynomials.showterm(io::IO, ::Type{P}, pj::T, var, j, first::Bool, mimetype) where {N, T, P <: AbstractSpecialPolynomial}
     iszero(pj) && return false
     !first &&  print(io, " ")
-    print(io, Polynomials.hasneg(T)  && Polynomials.isneg(pj) ? "- " :  (!first ? "+ " : ""))
-    print(io, "$(abs(pj))⋅$(basis_symbol(P))")
+    if Polynomials.hasneg(T)
+        print(io, Polynomials.isneg(pj) ? "-" :  (!first ? "+ " : ""))
+        print(io, "$(abs(pj))⋅$(basis_symbol(P))")
+    else
+        print(io, "$(pj)⋅$(basis_symbol(P))")
+    end
+
+
     unicode_subscript(io, j)
     print(io,"($(var))")
     return true

--- a/test/Bernstein.jl
+++ b/test/Bernstein.jl
@@ -49,7 +49,7 @@ end
     c = fromroots(Bernstein, r)
     @test roots(c) ≈ r
 
-    r = [1im, -1im]
+    r = [-1im, 1 + 2im]
     c = fromroots(Bernstein, r)
     @test roots(c) ≈ r
 end
@@ -108,7 +108,7 @@ end
     @test coeffs(z)  ==  zeros(length(z))
 
 
-    # GCD 
+    # GCD
     c1 = Bernstein(Float64[1//1, 2, 3])
     c2 = Bernstein(Float64[3//1, 2, 1])
     @test gcd(c1, c2) ≈ Bernstein([4.0])
@@ -155,5 +155,5 @@ end
         @test degree(truncate(pp, atol=1e-13)) <= 0
         @test degree(truncate(qq, atol=1e-13)) <  0
     end
-    
+
 end

--- a/test/Orthogonal-compare.jl
+++ b/test/Orthogonal-compare.jl
@@ -6,7 +6,7 @@
 
     T = Float64
 
-    for α in  (3/2, 1/2, 1, 2)  
+    for α in  (3/2, 1/2, 1, 2)
         P = Bessel{α,T}
         β =  2
 
@@ -22,7 +22,7 @@
         end
     end
 
-    
+
     x = variable(Polynomial)
     for  α  ∈ (1/4,1/2,3/4, 1, 2)
         P =  Bessel{α}
@@ -118,11 +118,11 @@ end
     P =  ChebyshevHermite
     for n in 2:5
         p  = basis(P,n)
-        @test  p(x) ≈ SP.classical_hypergeometric(P, n,  x)
+        @test  p(x) ≈ SP.classical_hypergeometric(P, n,  x) atol=1e-8
     end
 
 
-    
+
 end
 
 @testset "Legendre" begin
@@ -324,7 +324,7 @@ end
             end
         end
     end
-    
+
 end
 
 

--- a/test/Orthogonal.jl
+++ b/test/Orthogonal.jl
@@ -381,8 +381,8 @@ end
     end
 
 
-    # comrade matrix compared to conversion
-    for P ∈ (MonicLegendre, MonicChebyshev, MonicChebyshevU)
+    # comrade matrix approach compared to conversion
+    for P ∈ (Legendre, MonicLegendre, Chebyshev, MonicChebyshev, ChebyshevU, MonicChebyshevU)
         for T ∈ (Float64, Complex{Float64})
             ps = vcat(rand(T, 4), 1)
             p = P(ps)
@@ -391,6 +391,18 @@ end
             γs = sort(norm.(roots(q)))
             @test maximum(abs, λs - γs) < sqrt(eps())
         end
+    end
+
+    # comrade pencil
+    for P ∈ (Legendre, Chebyshev, ChebyshevU)
+        p = P(rand(5))
+        λ = rand()
+        C₀, C₁ = SP.comrade_pencil(p)
+        M = λ*C₁ - C₀
+        L,Ũ = SP.comrade_pencil_LU(p)(λ)
+        @test det(Ũ) ≈ 1
+        Ũ[end,end] *= p(λ)
+        @test L*Ũ ≈ M
     end
 
 end

--- a/test/Orthogonal.jl
+++ b/test/Orthogonal.jl
@@ -376,7 +376,7 @@ end
         for n in 6:2:10
             rts = roots(basis(P, n))
             evals = eigvals(SP.jacobi_matrix(P, n))
-            @test maximum(abs, sort(rts) - sort(evals)) <= 1e-4
+            @test maximum(abs,  rts - evals) <= 1e-4
         end
     end
 

--- a/test/Orthogonal.jl
+++ b/test/Orthogonal.jl
@@ -374,7 +374,7 @@ end
     for P in union(Ps, DPs)
         P <: Bessel && continue
         for n in 6:2:10
-            rts = roots(basis(P, n))
+            rts = roots(convert(Polynomial, basis(P, n)))
             evals = eigvals(SP.jacobi_matrix(P, n))
             @test maximum(abs,  rts - evals) <= 1e-4
         end

--- a/test/Orthogonal.jl
+++ b/test/Orthogonal.jl
@@ -27,10 +27,10 @@ DPs =  (Charlier{1/2},
         Krawchouk{1/2, 10},
         Hahn{1/4,1/2,10}
         )
-       
+
 
 @testset "Construction" begin
-    
+
     for P in union(Ps,  DPs)
         x = variable(P)
         # basic recurrence
@@ -38,7 +38,7 @@ DPs =  (Charlier{1/2},
         for n in 1:6
             @test basis(P,n+1) ≈ (SP.An(P,n) * x + SP.Bn(P,n)) * basis(P,n) - SP.Cn(P,n)*basis(P,n-1)
         end
-                
+
         # leading term and ratios
         x = variable(Polynomial)
         for n = 0:5
@@ -50,7 +50,7 @@ DPs =  (Charlier{1/2},
         for n = 1:5
             @test SP.k1k_1(P,n) ≈ SP.kn(P,n+1)/SP.kn(P,n-1)
         end
-        
+
         # basis
         x = variable(P)
         p0, p1, p2, p3, p4, p5, p6 = ps =  basis.(P,0:6)
@@ -95,7 +95,7 @@ DPs =  (Charlier{1/2},
 end
 
 @testset "Structural equations" begin
-    
+
     for P in Ps
         P  <: Hermite  &&  continue #  Hermite  has issues
         for i in 2:5
@@ -103,28 +103,28 @@ end
             ps = basis.(P, i+1:-1:i-1)
             dps = derivative.(ps)
             pᵢ,dpᵢ = ps[2], dps[2]
-            
+
             a,b,c,d,e = SP.abcde(P)
             x = variable(P)
             σ = a*x^2 + b*x + c
 
-            
+
             # x⋅p_n   = [an, bn, cn]    ⋅ [p_{n+1}, p_n, p_{n-1}]     #  Eqn (7)
             as= SP.an(P,i), SP.bn(P,i), SP.cn(P,i)
             @test x*pᵢ ≈ sum(a*p for (a,p) in zip(as, ps))
 
-            
+
             # σ⋅p'_n  = [αn, βn, γn]    ⋅  [p_{n+1}, p_n, p_{n-1}]    # Eqn (9), n ≥ 1
             αs = SP.αn(P,i), SP.βn(P,i), SP.γn(P,i)
             @test σ*dpᵢ ≈ sum(a*p for (a,p) in zip(αs, ps))
-            
+
             # p_n    = [ân, b̂n, ĉn]    ⋅  [p'_{n+1}, p'_n, p'_{n-1}] # Eqn (19)
             âs = SP.ân(P,i), SP.b̂n(P,i), SP.ĉn(P,i)
             @test pᵢ ≈ sum(a*dp for (a,dp) in zip(âs, dps))
-            
+
             # x⋅p'_n  = [αᴵn, βᴵn, γᴵn] ⋅  [p'_{n+1}, p'_n, p'_{n-1}] # Eqn  (14) with  α^*, β^*,  γ^*
             @test (a=a,b=b,c=c,d=d+2a,e=e+b)  == SP.abcdeᴵ(P)
-            αᴵs = SP.αᴵn(P,i), SP.βᴵn(P,i), SP.γᴵn(P,i) 
+            αᴵs = SP.αᴵn(P,i), SP.βᴵn(P,i), SP.γᴵn(P,i)
             @test x * dpᵢ ≈ sum(a*dp for (a,dp) in zip(αᴵs, dps))
         end
     end
@@ -135,7 +135,7 @@ end
             dps  = SP.:∇ₓ.(ps)
             Δps  = SP.:Δₓ.(ps)
             pᵢ,dpᵢ,Δpᵢ = ps[2], dps[2], Δps[2]
-            
+
             a,b,c,d,e = SP.abcde(P)
             x = variable(P)
             σ = a*x^2 + b*x + c
@@ -147,7 +147,7 @@ end
             αs = SP.αn(P,i), SP.βn(P,i), SP.γn(P,i)
             @test σ*dpᵢ ≈ sum(a*p for (a,p) in zip(αs, ps))
 
-            
+
             âs = SP.ân(P,i), SP.b̂n(P,i), SP.ĉn(P,i)  #  Eqn 20
             @test pᵢ ≈ sum(a*dp for (a,dp) in zip(âs, Δps))
 
@@ -157,9 +157,9 @@ end
 
         end
     end
-            
+
 end
-        
+
 
 @testset "Conversion" begin
 
@@ -171,7 +171,7 @@ end
                 p = P(ps)
                 @test convert(P, convert(Q, p)) ≈ p
             end
-        end            
+        end
     end
     # through evaluation
     for PP in (Ps, DPs)
@@ -184,7 +184,7 @@ end
         end
     end
 
-  
+
 
     x = variable(Polynomial)
     # Connections: groupings have same sigma = a⋅x² + b⋅x + c
@@ -193,19 +193,19 @@ end
                (Laguerre{0},  Laguerre{1/2}, Laguerre{1}),
                (Bessel{1/4}, Bessel{1/2}, Bessel{3/4}, Bessel{2})
                )
-        
-        
+
+
         for  P in Ps
             for Q in Ps
                 for n in 2:5
                     q = basis(Q, n)
                     # various ways to convert to P
-                    
+
                     @test q(variable(P))(variable()) ≈ q(variable())  # evaluation
                     @test SP._convert_cop(P, q)(variable()) ≈ q(variable())  # structural  equations
                     @test convert(P, convert(Polynomial, q))(variable()) ≈ q(variable()) # through Standard  basis
-                    @test convert(P, q)(x) ≈ q(x) 
-                    
+                    @test convert(P, q)(x) ≈ q(x)
+
                 end
             end
         end
@@ -219,8 +219,8 @@ end
             @test convert(Q, p)(x) ≈ p(x)
         end
     end
-            
-    
+
+
 end
 
 
@@ -260,7 +260,7 @@ end
                 @test (op(p,q))(x) ≈ op(p(x), q(x))
             end
         end
-        
+
     end
 end
 
@@ -305,8 +305,8 @@ end
         end
     end
 
-    
-        
+
+
 end
 
 
@@ -317,7 +317,7 @@ end
         ps, qs = rand(1:6, 4),rand(1:6, 3)
         p, q = P(ps), P(qs)
         a, b =  divrem(p, q)
-        @test p ≈ q  *  a +  b 
+        @test p ≈ q  *  a +  b
     end
 
 end
@@ -379,7 +379,20 @@ end
             @test maximum(abs, sort(rts) - sort(evals)) <= 1e-4
         end
     end
-    
+
+
+    # comrade matrix compared to conversion
+    for P ∈ (MonicLegendre, MonicChebyshev, MonicChebyshevU)
+        for T ∈ (Float64, Complex{Float64})
+            ps = vcat(rand(T, 4), 1)
+            p = P(ps)
+            q = convert(Polynomial, p)
+            λs = sort(norm.(roots(p)))
+            γs = sort(norm.(roots(q)))
+            @test maximum(abs, λs - γs) < sqrt(eps())
+        end
+    end
+
 end
 
 
@@ -407,7 +420,7 @@ end
         q = fit(Val(:series), P, f)
         @test maximum(abs, q(x) -  f(x) for x in range(0, stop=1/2, length=10)) <= sqrt(eps())
     end
-        
+
 end
 
 @testset "quadrature" begin
@@ -424,5 +437,3 @@ end
      end
 
 end
-
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using SpecialPolynomials; const SP=SpecialPolynomials
 using Polynomials
-import LinearAlgebra: eigvals, dot
+import LinearAlgebra: eigvals, dot, norm
 import SpecialFunctions: gamma
 using Test
 
@@ -15,4 +15,3 @@ using Test
 @testset "Newton" begin include("Newton.jl") end
 
 @testset "Bernstein" begin include("Bernstein.jl") end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using SpecialPolynomials; const SP=SpecialPolynomials
 using Polynomials
-import LinearAlgebra: eigvals, dot, norm
+import LinearAlgebra: eigvals, det, dot, norm
 import SpecialFunctions: gamma
 using Test
 


### PR DESCRIPTION
In #23 a discussion of using the comrade matrix to find the roots of polynomial is brought up.

This implements the algorithm of [Aurentz et al](DOI 10.1007/s10543-013-0449-x) to find the eigenvalues of the comrade matrix. 

Unlike the related algorithm in `AMRVW` for companion matrices, this algorithm is not claimed to be backward stable. Performance for large `n` may be suspect. The paper's recommendation is to check the roots, such a check is implemented in the non-exported `a_posteriori_check`. The method here is related to that in `AMRVW`, but the transforms are different so not much code could be leveraged. As such, this brings in no new dependencies.

Currently, the algorithm expects the polynomial family to have a monic basis. 

A test fails here when run locally, though that code does not produce an error when run outside of the package tests.