### PR TITLE
Add FastGaussQuadrature as dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["jverzani <jverzani@gmail.com>"]
 version = "0.2.3"
 
 [deps]
+FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 HypergeometricFunctions = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Minor issue.

```julia
julia> using FastGaussQuadrature
julia> using SpecialPolynomials
┌ Warning: Package SpecialPolynomials does not have FastGaussQuadrature in its dependencies:
│ - If you have SpecialPolynomials checked out for development and have
│   added FastGaussQuadrature as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with SpecialPolynomials
└ Loading FastGaussQuadrature into SpecialPolynomials from project dependency, future warnings for SpecialPolynomials are suppressed.
```