### PR TITLE
Fix markdown in the Chebyshev docstring

### DIFF
--- a/src/Orthogonal/Chebyshev.jl
+++ b/src/Orthogonal/Chebyshev.jl
@@ -3,7 +3,7 @@
 @register0 Chebyshev AbstractCCOP0
 export Chebyshev
 """
-   Chebyshev{<:Number}(coeffs::AbstractVector, var=:x)
+    Chebyshev{<:Number}(coeffs::AbstractVector, var=:x)
 
 Chebyshev polynomial of the first kind.
 


### PR DESCRIPTION
Change the number of spaces in the function signature in the docstring to 4, as required for markdown code rendering