### PR TITLE
fix type-instability in evalpoly

### DIFF
--- a/src/Orthogonal/cop.jl
+++ b/src/Orthogonal/cop.jl
@@ -156,7 +156,7 @@ function _eval_cop(P::Type{<:AbstractCOP{T,X,N}}, cs, x::S) where {T,X,N,S}
         quote
             Δ0 = cs[end - 1]
             Δ1 = cs[end]
-            @inbounds for i in Int(N - 1)::Int:-1:2
+            @inbounds for i in (Int(N)::Int - 1):-1:2
                 Δ0, Δ1 = cs[i - 1] - Δ1 * Cn(P, i - 1),
                 Δ0 + Δ1 * muladd(x, An(P, i - 1), Bn(P, i - 1))
             end

--- a/src/Orthogonal/cop.jl
+++ b/src/Orthogonal/cop.jl
@@ -156,7 +156,7 @@ function _eval_cop(P::Type{<:AbstractCOP{T,X,N}}, cs, x::S) where {T,X,N,S}
         quote
             Δ0 = cs[end - 1]
             Δ1 = cs[end]
-            @inbounds for i in (N - 1):-1:2
+            @inbounds for i in Int(N - 1)::Int:-1:2
                 Δ0, Δ1 = cs[i - 1] - Δ1 * Cn(P, i - 1),
                 Δ0 + Δ1 * muladd(x, An(P, i - 1), Bn(P, i - 1))
             end


### PR DESCRIPTION
Convert the degree to an `Int` in the loop. This should work in most cases, and gets rid of the type-instability in `evalpoly` even though the types aren't inferred concretely (#44).

Now:
```julia
julia> f(r) = (T = Chebyshev([1,1]); T(r))
f (generic function with 1 method)

julia> @code_warntype f(1.0)
MethodInstance for f(::Float64)
  from f(r) in Main at REPL[53]:1
Arguments
  #self#::Core.Const(f)
  r::Float64
Locals
  T::Chebyshev{Int64}
Body::Float64
1 ─ %1 = Base.vect(1, 1)::Vector{Int64}
│        (T = Main.Chebyshev(%1))
│   %3 = (T)(r)::Float64
└──      return %3
```

The return type is inferred correctly.
