### PR TITLE
throw error on mis convert; import constructorof

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpecialPolynomials"
 uuid = "a25cea48-d430-424a-8ee7-0d3ad3742e9e"
 authors = ["jverzani <jverzani@gmail.com>"]
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
@@ -17,7 +17,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 FastGaussQuadrature = "0.4"
 HypergeometricFunctions = "0.2, 0.3"
 Memoize = "0.4"
-Polynomials = "2, 3"
+Polynomials = "2.0.21, 3"
 QuadGK = "1,2"
 Requires = "1"
 SpecialFunctions = "0.09, 0.10, 1"

--- a/src/Orthogonal/orthogonal.jl
+++ b/src/Orthogonal/orthogonal.jl
@@ -101,7 +101,7 @@ weight_function(::P) where {P<:AbstractOrthogonalPolynomial} = weight_function(P
 The generating function is a function defined by: `(t,x) -> sum(t^n Pn(x) for n in 0:oo)`.
 """
 generating_function(::Type{P}) where {P<:AbstractOrthogonalPolynomial} =
-    throw(MethodError("Not implemented"))
+    throw(ArgumentError("Not implemented"))
 generating_function(::P) where {P<:AbstractOrthogonalPolynomial} = generating_function(P)
 
 """

--- a/src/SpecialPolynomials.jl
+++ b/src/SpecialPolynomials.jl
@@ -6,7 +6,7 @@ import SpecialFunctions: gamma
 
 using Polynomials
 import Polynomials:
-    basis, isconstant, constantterm, assert_same_variable, StandardBasisPolynomial, ⟒
+    basis, isconstant, constantterm, assert_same_variable, StandardBasisPolynomial, ⟒, constructorof
 export basis
 
 #import Intervals

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -21,13 +21,13 @@ abstract type AbstractSpecialPolynomial{T,X} <: Polynomials.AbstractPolynomial{T
 Base.eltype(::Type{<:AbstractSpecialPolynomial{T}}) where {T} = T
 Base.eltype(::Type{<:AbstractSpecialPolynomial}) = Float64
 
-# to strip off type parameters. See Polynomials.constructorof
-# We want ⟒(P{α,T,N}) = P{α} where {T, N}x
-@generated function constructorof(::Type{T}) where {T}
-    getfield(parentmodule(T), nameof(T))
-end
-⟒(P::Type{<:AbstractSpecialPolynomial}) = constructorof(P)
-⟒(::Type{<:Polynomial}) = Polynomial
+# use ArgumentError to give message. Also could use hint.
+Base.convert(::Type{Q}, p::P) where {P<:AbstractPolynomial, Q<:AbstractSpecialPolynomial} =
+    throw(ArgumentError("There is no `convert` method defined for a polynomial of type $P to one of type $Q. Maybe try converting through the `Polynomial` type (e.g `convert(Q, convert(Polynomial, p))`)"))
+
+# import ⟒ now
+#⟒(P::Type{<:AbstractSpecialPolynomial}) = constructorof(P)
+#⟒(::Type{<:Polynomial}) = Polynomial
 
 ## Display
 

--- a/test/Orthogonal.jl
+++ b/test/Orthogonal.jl
@@ -204,6 +204,9 @@ end
             @test convert(Q, p)(x) ≈ p(x)
         end
     end
+
+    # Issue #43 conversion from Polynomials.ChebyshevT
+    @test_throws ArgumentError convert(Legendre, ChebyshevT([0,1]))
 end
 
 @testset "Evaluation" begin


### PR DESCRIPTION
* close issue #43 as suggested, throw `ArgumentError` when `convert` is not available.
* import `constructorof` from recent `Polynomials` (bump compat)
*