### PR TITLE
Accept AbstractVector coeffs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "SpecialPolynomials"
 uuid = "a25cea48-d430-424a-8ee7-0d3ad3742e9e"
 authors = ["jverzani <jverzani@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
-FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 HypergeometricFunctions = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Memoize = "c03570c3-d221-55d1-a50c-7939bbd78826"
@@ -14,7 +13,6 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-FastGaussQuadrature = "0.4"
 HypergeometricFunctions = "0.2, 0.3"
 Memoize = "0.4"
 Polynomials = "2.0.21, 3"

--- a/src/Orthogonal/abstract.jl
+++ b/src/Orthogonal/abstract.jl
@@ -20,40 +20,27 @@ macro register0(name, parent)
                 end
                 new{T,X}(coeffs)
             end
-            function $poly{T,X}(coeffs::Vector{T}) where {T,X}
-                $poly{T,X}(Val(false), copy(coeffs))
-            end
-            function $poly{T,X}(coeffs::Vector{S}) where {T,X,S}
-                $poly{T,X}(Val(false), T.(coeffs))
+            function $poly{T,X}(coeffs::AbstractVector) where {T,X}
+                if Base.has_offset_axes(coeffs)
+                    @warn "Ignoring offset indices of the coefficient vector"
+                end
+                $poly{T,X}(Val(false), collect(T, coeffs))
             end
             function $poly{T,X}(coeffs::Tuple) where {T,X}
                 $poly{T,X}(Val(false), collect(T, coeffs))
             end
-            function $poly{T}(coeffs::Vector{S}, var::Polynomials.SymbolLike) where {T,S}
+            function $poly{T}(coeffs::Vector, var::Polynomials.SymbolLike = Polynomials.Var(:x)) where {T}
                 $poly{T, Symbol(var)}(coeffs)
             end
-            function $poly{T}(coeffs::Vector{S}) where {T,S}
-                $poly{T, :x}(coeffs)
+            function $poly{T}(coeffs::Tuple, var::Polynomials.SymbolLike = Polynomials.Var(:x)) where {T}
+                $poly{T,Symbol(var)}(collect(T, coeffs))
             end
-            function $poly{T}(coeffs::Tuple,var::Polynomials.SymbolLike) where {T,N,S}
-                $poly{T,Symbol(var)}(coeffs)
-            end
-            function $poly{T}(coeffs::Tuple) where {T,N,S}
-                $poly{T, :x}(coeffs)
-            end
-            function $poly(coeffs::Vector{T}, var::Polynomials.SymbolLike) where {T}
+            function $poly(coeffs::Vector{T}, var::Polynomials.SymbolLike = Polynomials.Var(:x)) where {T}
                 $poly{T}(coeffs, var)
             end
-            function $poly(coeffs::Vector{T}) where {T}
-                $poly{T, :x}(coeffs)
-            end
-            function $poly(coeffs::NTuple{N,T}, var::Polynomials.SymbolLike) where {N,T}
+            function $poly(coeffs::Tuple{Vararg{T}}, var::Polynomials.SymbolLike = Polynomials.Var(:x)) where {T}
                 $poly{T}(coeffs, var)
             end
-            function $poly(coeffs::NTuple{N,T}) where {N,T}
-                $poly{T, :x}(coeffs)
-            end
-
         end
 
         Base.length(p::$poly{T,X}) where {T,X} = length(p.coeffs)
@@ -81,43 +68,34 @@ macro registerN(name, parent, params...)
                 N == nothing && return new{$(αs...),T,X}(T[])
                 new{$(αs...),T,X}(T[coeffs[i] for i in firstindex(coeffs):N])
             end
-            function $poly{$(αs...),T,X}(coeffs::Vector{T}) where {$(αs...),T,X}
-                $poly{$(αs...),T,X}(Val(false), copy(coeffs))
-            end
-            function $poly{$(αs...),T,X}(coeffs::Vector{S}) where {$(αs...),T,X,S}
-                $poly{$(αs...),T,X}(Val(false), T.(coeffs))
+            function $poly{$(αs...),T,X}(coeffs::AbstractVector) where {$(αs...),T,X}
+                if Base.has_offset_axes(coeffs)
+                    @warn "Ignoring offset indices of the coefficient vector"
+                end
+                $poly{$(αs...),T,X}(Val(false), collect(T, coeffs))
             end
             function $poly{$(αs...),T,X}(coeffs::Tuple) where {$(αs...),T,X}
                 $poly{$(αs...),T,X}(Val(false), collect(T, coeffs))
             end
-            function $poly{$(αs...),T}(coeffs::Vector{S},var::Polynomials.SymbolLike) where {$(αs...),T,S}
+            function $poly{$(αs...),T}(coeffs::Vector,
+                    var::Polynomials.SymbolLike = Polynomials.Var(:x)) where {$(αs...),T}
                 $poly{$(αs...), T, Symbol(var)}(coeffs)
             end
-            function $poly{$(αs...),T}(coeffs::Vector{S}) where {$(αs...),T,S}
-                $poly{$(αs...), T, :x}(coeffs)
-            end
 
-            function $poly{$(αs...),T}(coeffs::Tuple,var::Polynomials.SymbolLike) where {$(αs...),T,N,S}
+            function $poly{$(αs...),T}(coeffs::Tuple,
+                    var::Polynomials.SymbolLike = Polynomials.Var(:x)) where {$(αs...),T}
                 $poly{$(αs...),T,Symbol(var)}(coeffs)
             end
-            function $poly{$(αs...),T}(coeffs::Tuple) where {$(αs...),T,N,S}
-                $poly{$(αs...),T, :x}(coeffs)
-            end
 
-            function $poly{$(αs...)}(coeffs::Vector{T},var::Polynomials.SymbolLike) where {$(αs...),T}
+            function $poly{$(αs...)}(coeffs::Vector{T},
+                    var::Polynomials.SymbolLike = Polynomials.Var(:x)) where {$(αs...),T}
                 $poly{$(αs...),T}(coeffs, var)
             end
-            function $poly{$(αs...)}(coeffs::Vector{T}) where {$(αs...),T}
-                $poly{$(αs...),T, :x}(coeffs)
-            end
 
-            function $poly{$(αs...)}(coeffs::NTuple{N, T},var::Polynomials.SymbolLike) where {$(αs...),N,T}
+            function $poly{$(αs...)}(coeffs::Tuple{Vararg{T}},
+                    var::Polynomials.SymbolLike = Polynomials.Var(:x)) where {$(αs...),T}
                 $poly{$(αs...),T}(coeffs, var)
             end
-            function $poly{$(αs...)}(coeffs::NTuple{N, T}) where {$(αs...),N,T}
-                $poly{$(αs...),T}(coeffs)
-            end
-
         end
 
         Base.length(ch::$poly{$(αs...),T,X}) where {$(αs...),T,X} = length(ch.coeffs)

--- a/test/Bernstein.jl
+++ b/test/Bernstein.jl
@@ -1,19 +1,24 @@
-@testset "Construction" for coeff in [
-    Int64[1, 1, 1, 1],
-    Float32[1, -4, 2],
-    ComplexF64[1 - 1im, 2 + 3im],
-    [3 // 4, -2 // 1, 1 // 1],
-]
-    p = Bernstein(coeff)
-    @test p.coeffs == coeff
-    @test coeffs(p) == coeff
-    @test degree(p) <= length(coeff) - 1
-    @test Polynomials.indeterminate(p) == :x
-    @test length(p) == length(coeff)
-    @test size(p) == size(coeff)
-    @test size(p, 1) == size(coeff, 1)
-    @test typeof(p).parameters[end - 1] == eltype(coeff)
-    @test eltype(p) == eltype(coeff)
+@testset "Construction" begin
+    @testset for coeff in [
+        Int64[1, 1, 1, 1],
+        Float32[1, -4, 2],
+        ComplexF64[1 - 1im, 2 + 3im],
+        [3 // 4, -2 // 1, 1 // 1],
+        # AbstractVector
+        view([1,2,3], :),
+        2:6,
+    ]
+        p = Bernstein(coeff)
+        @test p.coeffs == coeff
+        @test coeffs(p) == coeff
+        @test degree(p) <= length(coeff) - 1
+        @test Polynomials.indeterminate(p) == :x
+        @test length(p) == length(coeff)
+        @test size(p) == size(coeff)
+        @test size(p, 1) == size(coeff, 1)
+        @test typeof(p).parameters[end - 1] == eltype(coeff)
+        @test eltype(p) == eltype(coeff)
+    end
 end
 
 @testset "Other Construction" begin

--- a/test/ChebyshevT.jl
+++ b/test/ChebyshevT.jl
@@ -1,22 +1,27 @@
 ## Note:
 ## This is the `ChebyshevT.jl` test suite from the `Polynomials.jl` package by Miles Lucas
 
-@testset "Construction" for coeff in [
-    Int64[1, 1, 1, 1],
-    Float32[1, -4, 2],
-    ComplexF64[1 - 1im, 2 + 3im],
-    [3 // 4, -2 // 1, 1 // 1],
-]
-    p = Chebyshev(coeff)
-    @test p.coeffs == coeff
-    @test coeffs(p) == coeff
-    @test degree(p) == length(coeff) - 1
-    @test Polynomials.indeterminate(p) == :x
-    @test length(p) == length(coeff)
-    @test size(p) == size(coeff)
-    @test size(p, 1) == size(coeff, 1)
-    @test typeof(p).parameters[1] == eltype(coeff)
-    @test eltype(p) == eltype(coeff)
+@testset "Construction" begin
+    @testset for coeff in [
+        Int64[1, 1, 1, 1],
+        Float32[1, -4, 2],
+        ComplexF64[1 - 1im, 2 + 3im],
+        [3 // 4, -2 // 1, 1 // 1],
+        # AbstractVector
+        view([1.0, 2.0], :),
+        3:6
+    ]
+        p = @inferred Chebyshev(coeff)
+        @test p.coeffs == coeff
+        @test coeffs(p) == coeff
+        @test degree(p) == length(coeff) - 1
+        @test Polynomials.indeterminate(p) == :x
+        @test length(p) == length(coeff)
+        @test size(p) == size(coeff)
+        @test size(p, 1) == size(coeff, 1)
+        @test typeof(p).parameters[1] == eltype(coeff)
+        @test eltype(p) == eltype(coeff)
+    end
 end
 
 @testset "Other Construction" begin


### PR DESCRIPTION
After this PR, these work without needing to materialize the coefficients:
```julia
julia> Chebyshev(1:2:5)
Chebyshev(1⋅T₀(x) + 3⋅T₁(x) + 5⋅T₂(x))

julia> Chebyshev.(eachcol(Diagonal(ones(4))))
4-element Vector{Chebyshev{Float64, :x}}:
 Chebyshev(1.0⋅T₀(x))
 Chebyshev(1.0⋅T₁(x))
 Chebyshev(1.0⋅T₂(x))
 Chebyshev(1.0⋅T₃(x))
```

I've also cleaned up the code a bit, removed unused type parameters, and removed "FastGaussQuadrature" as a dependency as it was not being loaded.