### PR TITLE
remove unused type variable `N`

### DIFF
--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -42,7 +42,7 @@ function Polynomials.showterm(
     j,
     first::Bool,
     mimetype,
-) where {N,T,P<:AbstractSpecialPolynomial}
+) where {T,P<:AbstractSpecialPolynomial}
     iszero(pj) && return false
     !first && print(io, " ")
 


### PR DESCRIPTION
This shows up in precompilation warnings:
```julia
│  WARNING: method definition for showterm at [...]/.julia/packages/SpecialPolynomials/gLAGG/src/abstract.jl:37 declares type variable N but does not use it.
```